### PR TITLE
establishing codeowners for content review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,5 +14,5 @@ CODEOWNERS @heckj @shahmishal
 
 /api-guidelines/* @swiftlang/language-steering-group
 /ecosystem-tools/* @swiftlang/ecosystem-steering-group
-/language-guides/* @swifting/language-steering-group
+/language-guides/* @swiftang/language-steering-group
 /server-guides/* @swiftlang/server-workgroup


### PR DESCRIPTION
code owner structure for reviews for content areas - breaking up original PR #2 into separate PRs to land individually as we step this forward