### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "💬 Swift Documentation Forums"
+    url: "https://forums.swift.org/c/development/swift-docc/80"
+    about: "Discuss documentation content, propose major additions, or ask questions about Swift documentation"
+  - name: "🛠️ Documentation Tooling Forums"
+    url: "https://forums.swift.org/c/92"
+    about: "Questions about using Swift-DocC, documentation build tools, or authoring documentation"
+  - name: "📚 Swift Documentation Website"
+    url: "https://www.swift.org/documentation/"
+    about: "View the published Swift documentation"
+  - name: "📖 Contributing Guide"
+    url: "https://github.com/swiftlang/docs/blob/main/CONTRIBUTING.md"
+    about: "Read about style guidelines, proposing content, and the contribution process"

--- a/.github/ISSUE_TEMPLATE/content-error.yml
+++ b/.github/ISSUE_TEMPLATE/content-error.yml
@@ -1,0 +1,61 @@
+name: "Content Error"
+description: "Report inaccurate or incorrect information in existing documentation"
+labels: ["content error", "triage needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve the Swift documentation!
+
+        Use this template to report inaccurate, misleading, or incorrect content.
+        If you're suggesting improvements without claiming inaccuracy, use the Enhancement template instead.
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: "Documentation Package"
+      description: "Which package contains the error?"
+      options:
+        - API Guidelines
+        - Language Guides
+        - Server Guides
+        - Ecosystem Tools
+        - Not sure / Multiple packages
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: "Location (URL)"
+      description: "The URL of the page with the error (from swift.org or local preview)"
+      placeholder: "https://www.swift.org/documentation/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "What's wrong with the current content?"
+      placeholder: "Be specific about what information is incorrect or inaccurate"
+    validations:
+      required: true
+
+  - type: textarea
+    id: correction
+    attributes:
+      label: "Suggested Correction"
+      description: "What should the documentation say instead?"
+      placeholder: "Provide the corrected information or approach"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Additional Context"
+      description: "Any supporting information, references, or examples"
+      placeholder: "Links to Swift Evolution proposals, API documentation, or code examples"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/content-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/content-proposal.yml
@@ -1,0 +1,76 @@
+name: "Content Proposal"
+description: "Propose new documentation topics or articles"
+labels: ["content proposal", "needs forum discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for proposing new Swift documentation!
+
+        For significant new content, please consider starting a discussion on the
+        [Swift Forums](https://forums.swift.org/c/development/swift-docc/80) first.
+
+        See our [Contributing Guide](https://github.com/swiftlang/docs/blob/main/CONTRIBUTING.md)
+        for guidance on proposing larger content additions.
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: "Target Package"
+      description: "Which package should contain this new content?"
+      options:
+        - API Guidelines
+        - Language Guides
+        - Server Guides
+        - Ecosystem Tools
+        - New package needed
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: "Suggested Location"
+      description: "Where should this content be added? (chapter, section, or new article)"
+      placeholder: "e.g., 'Language Guides > Concurrency' or 'New article in Server Guides'"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Content Description"
+      description: "What should this new documentation cover?"
+      placeholder: "Provide a clear summary of the proposed content"
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivation"
+      description: "Why is this documentation needed?"
+      placeholder: "What problem does this solve? What audience would benefit?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: "Scope and Outline"
+      description: "What topics should be covered? (optional outline)"
+      placeholder: |
+        - Topic 1
+        - Topic 2
+        - Examples needed
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives Considered"
+      description: "Have you considered other approaches or locations for this content?"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,80 @@
+name: "Enhancement / Improvement"
+description: "Suggest improvements to existing documentation (without claiming inaccuracy)"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve the Swift documentation!
+
+        Use this template for:
+        - Adding examples or code snippets
+        - Improving clarity or wording
+        - Restructuring for better flow
+        - Adding cross-references or links
+
+        If content is factually incorrect, use the "Content Error" template instead.
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: "Documentation Package"
+      description: "Which package would this improve?"
+      options:
+        - API Guidelines
+        - Language Guides
+        - Server Guides
+        - Ecosystem Tools
+        - Multiple packages
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: "Location (URL)"
+      description: "URL of the content to improve"
+      placeholder: "https://www.swift.org/documentation/..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: improvement_type
+    attributes:
+      label: "Type of Improvement"
+      description: "What kind of enhancement are you suggesting?"
+      options:
+        - Add examples or code samples
+        - Improve clarity or wording
+        - Add diagrams or illustrations
+        - Restructure or reorganize
+        - Add cross-references or links
+        - Expand coverage of topic
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: "Current State"
+      description: "What does the documentation currently say or show?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_improvement
+    attributes:
+      label: "Proposed Improvement"
+      description: "How should it be improved?"
+      placeholder: "Be specific about what you'd like to see added or changed"
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: "Benefit"
+      description: "How will this improvement help readers?"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,75 @@
+name: "⚙️ Track a Task"
+description: "Track internal work, technical debt, or maintenance tasks"
+labels: ["task", "triage needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tasks track internal work items including:
+        - Technical debt or maintenance
+        - Build system or tooling updates
+        - Documentation infrastructure improvements
+        - Multi-step work that needs coordination
+
+        For content changes, consider using Content Error, Enhancement, or Content Proposal templates.
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: "Affected Package(s)"
+      description: "Which packages does this task affect?"
+      multiple: true
+      options:
+        - API Guidelines
+        - Language Guides
+        - Server Guides
+        - Ecosystem Tools
+        - Repository infrastructure
+        - All packages
+    validations:
+      required: true
+
+  - type: dropdown
+    id: task_type
+    attributes:
+      label: "Task Type"
+      description: "What kind of task is this?"
+      options:
+        - Technical debt
+        - Build system update
+        - Tooling improvement
+        - Infrastructure maintenance
+        - Process improvement
+        - Coordination / umbrella issue
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "A clear description of the task"
+      placeholder: "Describe what needs to be done and why"
+    validations:
+      required: true
+
+  - type: textarea
+    id: subtasks
+    attributes:
+      label: "Subtasks or Checklist"
+      description: "Break down the work into steps (optional)"
+      placeholder: |
+        - [ ] Step 1
+        - [ ] Step 2
+        - [ ] Step 3
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: "Additional Information"
+      description: "Any context, dependencies, or related issues"
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,77 @@
+## Summary
+
+<!-- Provide a clear description of what this PR changes and why -->
+
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses -->
+Closes: #
+
+
+## Type of Change
+
+<!-- Mark the relevant option with an [x] -->
+- [ ] Content error fix (corrects inaccurate information)
+- [ ] Enhancement (improves existing content)
+- [ ] New content (adds new documentation)
+- [ ] Technical change (build system, tooling, infrastructure)
+- [ ] Typo or formatting fix
+
+
+## Documentation Package(s) Affected
+
+<!-- Mark all that apply with an [x] -->
+- [ ] API Guidelines
+- [ ] Language Guides
+- [ ] Server Guides
+- [ ] Ecosystem Tools
+- [ ] Repository infrastructure
+
+
+## Changes Made
+
+<!-- List the specific changes in this PR -->
+-
+-
+-
+
+
+## Testing
+
+<!-- How can reviewers verify these changes? -->
+
+### Build Verification
+- [ ] Ran `swift package generate-documentation --analyze --warnings-as-errors` successfully
+- [ ] Previewed documentation locally with `swift package --disable-sandbox preview-documentation`
+
+### Content Review
+- [ ] Changes follow the [Apple Style Guide](https://help.apple.com/applestyleguide/)
+- [ ] Changes follow [TSPL style guidelines](https://github.com/swiftlang/swift-book/blob/main/Style.md#terms-and-rules)
+- [ ] Code examples compile and run as expected
+- [ ] Links and cross-references are valid
+
+
+## Technical Review Required
+
+<!-- This checkbox MUST be completed before merge -->
+- [ ] **Technical review completed by appropriate CODEOWNERS**
+
+<!--
+Technical review ensures content accuracy and correctness.
+See .github/CODEOWNERS for reviewers by package:
+- API Guidelines: @swiftlang/language-steering-group
+- Language Guides: @swiftlang/language-steering-group
+- Server Guides: @swiftlang/server-workgroup
+- Ecosystem Tools: @swiftlang/ecosystem-steering-group
+-->
+
+
+## Additional Notes
+
+<!-- Any additional context, screenshots, or information for reviewers -->
+
+
+---
+<!-- Do not edit below this line -->
+**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**


### PR DESCRIPTION
This commit adds comprehensive issue and PR templates for the docs repository:

resolves #27 

Issue Templates (YAML format):
- content-error.yml: Report inaccurate documentation with URL-based locations
- content-proposal.yml: Propose new documentation topics
- enhancement.yml: Suggest improvements to existing content
- task.yml: Track technical debt and maintenance work
- config.yml: Configure template chooser with forum links

Pull Request Template:
- Structured sections for summary, related issues, and changes
- Package selection checkboxes for routing to CODEOWNERS
- Build verification and content review checklists
- Required technical review checkbox
- Apache 2.0 license confirmation

These templates support state-based lifecycle tracking (proposed, approved, drafting, in-review) and integrate with the existing CODEOWNERS structure.