### PR TITLE
adding in android examples to combined doc collection

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -69,7 +69,7 @@
       "type": "git",
       "repo": "https://github.com/swiftlang/swift-embedded-examples.git",
       "ref": "main",
-      "docc_catalog": "Sources/EmbeddedSwift/Documentation.docc"
+      "docc_catalog": "Sources/EmbeddedSwift/EmbeddedSwift.docc"
     },
     {
       "id": "swift-wasm",

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -85,6 +85,13 @@
       "targets": ["ServerGuides"]
     },
     {
+      "id": "swift-android",
+      "type": "git",
+      "repo": "https://github.com/swiftlang/swift-android-examples.git",
+      "ref": "main",
+      "targets": ["SwiftAndroid"]
+    },
+    {
       "id": "swift-server-todos-tutorial",
       "type": "git",
       "repo": "https://github.com/swiftlang/swift-server-todos-tutorial.git",


### PR DESCRIPTION
## Summary

Adds the content from swift-android-examples into the combined DocC archive.

Depends on:
- https://github.com/swiftlang/swift-embedded-examples/pull/205
- https://github.com/swiftlang/swift-android-examples/pull/43

The current build fails due to conflicting merge elements between swift-android-examples and swift-embedded-examples. The PRs update both to avoid the conflict (only one strictly needed, but any following that documentation structure will run into the same issues)

## Validation

- [x] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [x] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
