### PR TITLE
adds support to pull in and merge a remotely-built docc archive, as well as better swiftly accommodation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Package.resolved
 .build-output/
 **/*.docc/header.html
 **/*.docc/footer.html
+scripts/__pycache__/

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -376,6 +376,31 @@ def validate_sources(config):
     return errors
 
 
+def clean_package_build_dirs(root_dir, sources):
+    """Remove `.build/` dirs for every local Swift package this script touches.
+
+    Targets the union of: `local`-typed sources in `sources.json` (their
+    `path` resolved under `root_dir`) and any sibling of `root_dir` that
+    contains a `Package.swift`. Existence of `Package.swift` gates the
+    repo-root sweep so unrelated subdirectories like `common/` are left alone.
+    Returns the list of removed `.build/` paths in deterministic order.
+    """
+    targets = set()
+    for s in sources:
+        if s.get("type") == "local" and s.get("path"):
+            targets.add((root_dir / s["path"]).resolve())
+    for pkg_manifest in root_dir.glob("*/Package.swift"):
+        targets.add(pkg_manifest.parent.resolve())
+
+    removed = []
+    for pkg_dir in sorted(targets):
+        build_dir = pkg_dir / ".build"
+        if build_dir.exists():
+            shutil.rmtree(str(build_dir))
+            removed.append(build_dir)
+    return removed
+
+
 def clone_or_update(source, workspace, ref):
     """Git clone or fetch+checkout for a given ref. Returns the source directory."""
     source_id = source["id"]
@@ -926,6 +951,8 @@ def main():
         print(f"Removing workspace: {workspace}")
         if workspace.exists():
             shutil.rmtree(str(workspace))
+        for build_dir in clean_package_build_dirs(root_dir, sources):
+            print(f"Removed package build dir: {build_dir}")
 
     output_dir.mkdir(parents=True, exist_ok=True)
     workspace.mkdir(parents=True, exist_ok=True)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -25,6 +25,7 @@ import tarfile
 import urllib.error
 import urllib.request
 import zipfile
+from collections import namedtuple
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -86,45 +87,41 @@ def check_prerequisites():
             sys.exit(1)
 
 
-def find_docc_command():
-    """Find the docc tool — prefer swiftly proxy, then xcrun on macOS, then PATH.
+Tools = namedtuple("Tools", ["swiftly", "swift", "docc"])
 
-    Routing through swiftly when available ensures the docc invocation honors
-    any `.swift-version` file in the working directory.
-    Returns a list of command components (e.g. ["swiftly", "run", "docc"]
-    or ["xcrun", "docc"] or ["docc"]), or an empty list if docc is not found.
+
+def discover_tools():
+    """Discover the swift toolchain commands available in PATH.
+
+    Returns a `Tools` triple of command prefixes (each a list; empty when
+    unavailable). When swiftly is present, all three route through it so
+    `.swift-version` files are honored at command-resolution time. Otherwise
+    swift comes directly from PATH, and docc is located via `xcrun --find`
+    on macOS with a fallback to PATH.
     """
     if shutil.which("swiftly"):
-        return ["swiftly", "run", "docc"]
+        return Tools(
+            swiftly=["swiftly"],
+            swift=["swiftly", "run", "swift"],
+            docc=["swiftly", "run", "docc"],
+        )
+
+    swift = ["swift"] if shutil.which("swift") else []
+
+    docc = []
     if shutil.which("xcrun"):
         try:
             subprocess.run(
                 ["xcrun", "--find", "docc"],
-                check=True,
-                capture_output=True,
+                check=True, capture_output=True,
             )
-            return ["xcrun", "docc"]
+            docc = ["xcrun", "docc"]
         except subprocess.CalledProcessError:
             pass
-    if shutil.which("docc"):
-        return ["docc"]
-    return []
+    if not docc and shutil.which("docc"):
+        docc = ["docc"]
 
-
-def find_swiftly():
-    """Return ['swiftly'] if swiftly is on PATH, else []."""
-    if shutil.which("swiftly"):
-        return ["swiftly"]
-    return []
-
-
-def find_swift_command():
-    """Find swift — prefer swiftly proxy so .swift-version files are honored."""
-    if shutil.which("swiftly"):
-        return ["swiftly", "run", "swift"]
-    if shutil.which("swift"):
-        return ["swift"]
-    return []
+    return Tools(swiftly=[], swift=swift, docc=docc)
 
 
 def ensure_toolchain_installed(source_dir, swiftly_cmd):
@@ -150,6 +147,92 @@ def ensure_toolchain_installed(source_dir, swiftly_cmd):
 _TOOLS_VERSION_RE = re.compile(
     r"^//\s*swift-tools-version\s*:\s*(\d+(?:\.\d+){0,2})"
 )
+
+_SWIFT_VERSION_RE = re.compile(r"Swift version (\d+)\.(\d+)")
+
+
+def get_active_swift_version():
+    """Return the active swift toolchain as (major, minor), or None.
+
+    Runs `swift --version` and parses the version line. When swiftly is
+    installed, `swift` is its proxy and reports the active toolchain;
+    otherwise this reports the system swift. Returns None if swift is
+    unavailable, the invocation fails, or the output can't be parsed.
+    """
+    if shutil.which("swift") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["swift", "--version"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    m = _SWIFT_VERSION_RE.search(result.stdout)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def select_swift_toolchain(swift_cmd, source_dir, swiftly_cmd, active_swift_version):
+    """Decide whether to pin a specific swiftly toolchain for this source.
+
+    Package.swift's `swift-tools-version` declares a *minimum* toolchain. If
+    the active toolchain already meets that minimum, the default is fine and
+    we leave swift_cmd alone. Only when the active toolchain is older (or
+    unknown) do we install the required version and pin via `+X.Y`.
+
+    Returns swift_cmd unchanged when:
+      - swiftly is unavailable
+      - source_dir has a `.swift-version` file (handled by
+        ensure_toolchain_installed; that path takes precedence)
+      - Package.swift has no recognizable tools-version line
+      - active_swift_version >= the tools-version
+
+    Otherwise installs the tools-version via swiftly and returns
+    swift_cmd + ['+X.Y']. If installation fails, returns swift_cmd unchanged
+    so the build can proceed against whatever's available.
+    """
+    if not swiftly_cmd:
+        return swift_cmd
+    if (source_dir / ".swift-version").is_file():
+        return swift_cmd
+    tools_version = read_swift_tools_version(source_dir)
+    if not tools_version:
+        return swift_cmd
+
+    parts = tools_version.split(".")
+    try:
+        required = (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
+    except ValueError:
+        return swift_cmd
+
+    if active_swift_version is not None and active_swift_version >= required:
+        print(
+            f"Active swift toolchain {active_swift_version[0]}."
+            f"{active_swift_version[1]} satisfies Package.swift requirement "
+            f"{tools_version}; using default."
+        )
+        return swift_cmd
+
+    print(
+        f"Package.swift requires swift-tools-version {tools_version}; "
+        f"using `swiftly +{tools_version}`."
+    )
+    try:
+        subprocess.run(
+            swiftly_cmd + ["install", tools_version, "--assume-yes"],
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(
+            f"  Note: `swiftly install {tools_version}` failed ({e}); "
+            "continuing with default toolchain."
+        )
+        return swift_cmd
+    return swift_cmd + [f"+{tools_version}"]
 
 
 def read_swift_tools_version(source_dir):
@@ -180,7 +263,13 @@ def read_swift_tools_version(source_dir):
 
 
 def validate_sources(config):
-    """Validate the loaded JSON structure."""
+    """Return a list of validation error strings; empty list means valid.
+
+    Pure check — does not print or exit. The caller decides how to surface
+    errors. Returns early after structural problems (missing top-level keys,
+    `sources` not a list) so per-entry validation only runs against a sane
+    shape.
+    """
     errors = []
 
     if "version" not in config:
@@ -188,18 +277,12 @@ def validate_sources(config):
 
     if "sources" not in config:
         errors.append("Top-level 'sources' field is missing")
-        # Can't validate further without sources
-        if errors:
-            for e in errors:
-                print(f"Validation error: {e}")
-            sys.exit(1)
+        return errors
 
     sources = config["sources"]
     if not isinstance(sources, list):
         errors.append("'sources' must be an array")
-        for e in errors:
-            print(f"Validation error: {e}")
-        sys.exit(1)
+        return errors
 
     for i, entry in enumerate(sources):
         entry_id = entry.get("id", "")
@@ -290,13 +373,7 @@ def validate_sources(config):
         if "preflight" in entry and not entry["preflight"]:
             errors.append(f"{label} has 'preflight' but it is empty")
 
-    if errors:
-        for e in errors:
-            print(f"Validation error: {e}")
-        print(f"\nFix the errors in sources.json before continuing.")
-        sys.exit(1)
-
-    print(f"Validated {len(sources)} source entries.")
+    return errors
 
 
 def clone_or_update(source, workspace, ref):
@@ -473,11 +550,144 @@ def add_docc_plugin(source_dir, swift_cmd):
     )
 
 
-def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc_cmd, env, swift_cmd=None, swiftly_cmd=None):
+def _build_archive_source(source, workspace, temp_archive_dir):
+    """Fetch an archive source, copy it into the staging dir, optionally strip.
+
+    Returns (archives, manifest_entry). Raises ArchiveFetchError on download
+    or extraction failure (caller treats this as fatal).
+    """
+    source_id = source["id"]
+    archive_path = fetch_archive(source, workspace)
+    dest = temp_archive_dir / f"{source_id}.doccarchive"
+    if dest.exists():
+        shutil.rmtree(str(dest))
+    shutil.copytree(str(archive_path), str(dest))
+    print(f"Copied {archive_path} -> {dest}")
+
+    if source.get("strip_availability"):
+        print(f"Stripping availability from {dest}...")
+        scanned, modified, removed = strip_archive(dest)
+        print(
+            f"  scanned {scanned} files; modified {modified}; "
+            f"removed {removed} 'platforms' keys"
+        )
+
+    manifest_entry = {
+        "id": source_id,
+        "type": "archive",
+        "ref": source.get("version_label", ""),
+        "commit": "",
+        "url": source["url"],
+    }
+    return [dest], manifest_entry
+
+
+def _build_package_targets(source, source_dir, common_dir, temp_archive_dir, swift_cmd, env):
+    """Build each Swift package target with `swift package generate-documentation`."""
+    source_id = source["id"]
+    targets = source["targets"]
+    extra_flags = source.get("extra_flags", [])
+
+    for target in targets:
+        catalog_dir = find_docc_catalog_for_target(source_dir, target, swift_cmd)
+        if catalog_dir:
+            install_templates(catalog_dir, common_dir, f"{source_id}/{target}")
+        else:
+            print(
+                f"  Note: could not locate .docc catalog for target '{target}', "
+                "skipping template install"
+            )
+
+    archives = []
+    for target in targets:
+        print(f"Building target: {target}")
+        cmd = swift_cmd + [
+            "package", "generate-documentation",
+            "--target", target,
+        ] + DOCC_BUILD_FLAGS + extra_flags
+        subprocess.run(cmd, cwd=str(source_dir), check=True, env=env)
+
+        archive = find_doccarchive(source_dir, target)
+        if not archive:
+            raise RuntimeError(
+                f"could not find .doccarchive for target '{target}'"
+            )
+
+        output_name = source_id if len(targets) == 1 else f"{source_id}-{target}"
+        dest = temp_archive_dir / f"{output_name}.doccarchive"
+        if dest.exists():
+            shutil.rmtree(str(dest))
+        shutil.copytree(str(archive), str(dest))
+        print(f"Exported {archive} -> {dest}")
+        archives.append(dest)
+    return archives
+
+
+def _build_docc_catalog(source, source_dir, common_dir, temp_archive_dir, docc_cmd, env):
+    """Convert a standalone `.docc` catalog with `docc convert`."""
+    source_id = source["id"]
+    docc_catalog = source["docc_catalog"]
+    extra_flags = source.get("extra_flags", [])
+
+    catalog_path = source_dir / docc_catalog
+    if not catalog_path.is_dir():
+        raise RuntimeError(f"docc catalog not found at '{catalog_path}'")
+    if not docc_cmd:
+        raise RuntimeError("'docc' tool not found (tried xcrun and PATH)")
+
+    install_templates(catalog_path, common_dir, source_id)
+
+    dest = temp_archive_dir / f"{source_id}.doccarchive"
+    if dest.exists():
+        shutil.rmtree(str(dest))
+
+    print("Converting catalog with docc convert...")
+    cmd = docc_cmd + [
+        "convert", str(catalog_path),
+        "--output-path", str(dest),
+    ] + DOCC_BUILD_FLAGS + extra_flags
+    subprocess.run(cmd, check=True, env=env)
+    return [dest]
+
+
+def _collect_git_metadata(source_dir, configured_ref=None):
+    """Read (ref, commit) from a git working tree.
+
+    For git-type sources, configured_ref is the ref from sources.json and is
+    returned verbatim — only the commit comes from `git rev-parse HEAD`. For
+    local sources (configured_ref is None), both come from git, defaulting to
+    'unknown' when the working tree isn't a git checkout.
+    """
+    if configured_ref is not None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+                capture_output=True, text=True, check=True,
+            )
+            return configured_ref, result.stdout.strip()
+        except subprocess.CalledProcessError:
+            return configured_ref, "unknown"
+
+    try:
+        ref_result = subprocess.run(
+            ["git", "-C", str(source_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        commit_result = subprocess.run(
+            ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return ref_result.stdout.strip(), commit_result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return "unknown", "unknown"
+
+
+def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc_cmd, env, swift_cmd=None, swiftly_cmd=None, active_swift_version=None):
     """Build a single source entry.
 
-    Returns a tuple of (list_of_archive_paths, manifest_entry) on success,
-    or raises an exception on failure.
+    Returns (archives, manifest_entry) on success. Dispatches to a helper for
+    each source type; archive sources short-circuit before any toolchain or
+    preflight setup.
     """
     if swift_cmd is None:
         swift_cmd = ["swift"]
@@ -486,9 +696,6 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
 
     source_id = source["id"]
     source_type = source["type"]
-    docc_catalog = source.get("docc_catalog", "")
-    targets = source.get("targets", [])
-    extra_flags = source.get("extra_flags", [])
 
     print()
     print("=" * 40)
@@ -496,175 +703,48 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
     print("=" * 40)
 
     if source_type == "archive":
-        archive_path = fetch_archive(source, workspace)
-        dest = temp_archive_dir / f"{source_id}.doccarchive"
-        if dest.exists():
-            shutil.rmtree(str(dest))
-        shutil.copytree(str(archive_path), str(dest))
-        print(f"Copied {archive_path} -> {dest}")
-
-        if source.get("strip_availability"):
-            print(f"Stripping availability from {dest}...")
-            scanned, modified, removed = strip_archive(dest)
-            print(
-                f"  scanned {scanned} files; modified {modified}; "
-                f"removed {removed} 'platforms' keys"
-            )
-
-        manifest_entry = {
-            "id": source_id,
-            "type": "archive",
-            "ref": source.get("version_label", ""),
-            "commit": "",
-            "url": source["url"],
-        }
+        archives, manifest_entry = _build_archive_source(
+            source, workspace, temp_archive_dir
+        )
         print(f"Done: {source_id}")
-        return [dest], manifest_entry
+        return archives, manifest_entry
 
-    # Resolve source directory
     if source_type == "local":
         source_dir = root_dir / source["path"]
         if not source_dir.is_dir():
             raise RuntimeError(f"local path '{source_dir}' does not exist")
     elif source_type == "git":
-        ref = source["ref"]
-        source_dir = clone_or_update(source, workspace, ref)
+        source_dir = clone_or_update(source, workspace, source["ref"])
     else:
         raise RuntimeError(f"unknown type '{source_type}'")
 
-    # If the source pins a specific Swift toolchain, ensure it's installed
-    # before any swift/docc command runs against it.
     ensure_toolchain_installed(source_dir, swiftly_cmd)
+    swift_cmd = select_swift_toolchain(
+        swift_cmd, source_dir, swiftly_cmd, active_swift_version
+    )
 
-    # Fallback: if no `.swift-version` exists but Package.swift declares a
-    # minimum tools-version, route swift/docc through swiftly with that
-    # version as a `+selector`. This lets repos that pin via Package.swift
-    # (e.g. swift-testing) build without manual swiftly setup.
-    if (
-        swiftly_cmd
-        and not (source_dir / ".swift-version").is_file()
-    ):
-        tools_version = read_swift_tools_version(source_dir)
-        if tools_version:
-            print(
-                f"Package.swift requires swift-tools-version {tools_version}; "
-                f"using `swiftly +{tools_version}`."
-            )
-            try:
-                subprocess.run(
-                    swiftly_cmd + ["install", tools_version, "--assume-yes"],
-                    check=True,
-                )
-            except subprocess.CalledProcessError as e:
-                print(
-                    f"  Note: `swiftly install {tools_version}` failed ({e}); "
-                    "continuing with default toolchain."
-                )
-            else:
-                swift_cmd = swift_cmd + [f"+{tools_version}"]
-
-    # Run preflight command if configured
     preflight = source.get("preflight", "")
     if preflight:
         print(f"Running preflight: {preflight}")
         subprocess.run(
             ["bash", "-c", preflight],
-            cwd=str(source_dir),
-            check=True,
-            env=env,
+            cwd=str(source_dir), check=True, env=env,
         )
 
-    # Inject swift-docc-plugin if requested
     if source.get("add_docc_plugin"):
         add_docc_plugin(source_dir, swift_cmd)
 
-    archives = []
-
-    if targets:
-        # Install templates into each target's .docc catalog
-        for target in targets:
-            catalog_dir = find_docc_catalog_for_target(source_dir, target, swift_cmd)
-            if catalog_dir:
-                install_templates(catalog_dir, common_dir, f"{source_id}/{target}")
-            else:
-                print(
-                    f"  Note: could not locate .docc catalog for target '{target}', "
-                    "skipping template install"
-                )
-
-        # Build each target via swift package
-        for target in targets:
-            print(f"Building target: {target}")
-            cmd = swift_cmd + [
-                "package", "generate-documentation",
-                "--target", target,
-            ] + DOCC_BUILD_FLAGS + extra_flags
-            subprocess.run(cmd, cwd=str(source_dir), check=True, env=env)
-
-            archive = find_doccarchive(source_dir, target)
-            if not archive:
-                raise RuntimeError(
-                    f"could not find .doccarchive for target '{target}'"
-                )
-
-            output_name = source_id if len(targets) == 1 else f"{source_id}-{target}"
-            dest = temp_archive_dir / f"{output_name}.doccarchive"
-            if dest.exists():
-                shutil.rmtree(str(dest))
-            shutil.copytree(str(archive), str(dest))
-            print(f"Exported {archive} -> {dest}")
-            archives.append(dest)
+    if source.get("targets"):
+        archives = _build_package_targets(
+            source, source_dir, common_dir, temp_archive_dir, swift_cmd, env
+        )
     else:
-        # Use docc convert directly
-        catalog_path = source_dir / docc_catalog
-        if not catalog_path.is_dir():
-            raise RuntimeError(f"docc catalog not found at '{catalog_path}'")
+        archives = _build_docc_catalog(
+            source, source_dir, common_dir, temp_archive_dir, docc_cmd, env
+        )
 
-        if not docc_cmd:
-            raise RuntimeError("'docc' tool not found (tried xcrun and PATH)")
-
-        install_templates(catalog_path, common_dir, source_id)
-
-        dest = temp_archive_dir / f"{source_id}.doccarchive"
-        if dest.exists():
-            shutil.rmtree(str(dest))
-
-        print("Converting catalog with docc convert...")
-        cmd = docc_cmd + [
-            "convert", str(catalog_path),
-            "--output-path", str(dest),
-        ] + DOCC_BUILD_FLAGS + extra_flags
-        subprocess.run(cmd, check=True, env=env)
-        archives.append(dest)
-
-    # Build manifest entry
-    commit_sha = ""
-    actual_ref = ""
-    if source_type == "git":
-        actual_ref = source["ref"]
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
-                capture_output=True, text=True, check=True,
-            )
-            commit_sha = result.stdout.strip()
-        except subprocess.CalledProcessError:
-            commit_sha = "unknown"
-    elif source_type == "local":
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(source_dir), "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True, text=True, check=True,
-            )
-            actual_ref = result.stdout.strip()
-            result = subprocess.run(
-                ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
-                capture_output=True, text=True, check=True,
-            )
-            commit_sha = result.stdout.strip()
-        except subprocess.CalledProcessError:
-            actual_ref = "unknown"
-            commit_sha = "unknown"
+    configured_ref = source["ref"] if source_type == "git" else None
+    actual_ref, commit_sha = _collect_git_metadata(source_dir, configured_ref)
 
     manifest_entry = {
         "id": source_id,
@@ -672,7 +752,6 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
         "ref": actual_ref,
         "commit": commit_sha,
     }
-
     print(f"Done: {source_id}")
     return archives, manifest_entry
 
@@ -728,6 +807,53 @@ def transform_static_hosting(archive_path, hosting_base_path, docc_cmd):
     print(f"Transformed archive: {archive_path}")
 
 
+def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prior_failed):
+    """Merge per-source archives and apply the static-hosting transform.
+
+    Returns (succeeded_steps, failed_steps): names that should be added to
+    the build summary's success and failure lists, respectively. Bails early
+    on missing prerequisites; isolates the merge step from the transform step
+    so a transform failure still records the merge as succeeded.
+    """
+    print()
+    print("=" * 40)
+    print("Merging combined documentation archive")
+    print("=" * 40)
+
+    if prior_failed:
+        print("Error: cannot merge — the following sources failed to build:")
+        for fid in prior_failed:
+            print(f"  - {fid}")
+        print("Skipping merge step.")
+        return [], ["combined-merge"]
+
+    if not docc_cmd:
+        print("Error: 'docc' tool not found, cannot merge archives")
+        return [], ["combined-merge"]
+
+    missing = [a for a in all_archives if not a.is_dir()]
+    if missing:
+        print("Error: the following expected archives are missing:")
+        for ma in missing:
+            print(f"  - {ma}")
+        return [], ["combined-merge"]
+
+    combined_output = output_dir / f"{version}"
+    try:
+        merge_archives(all_archives, combined_output, docc_cmd)
+    except subprocess.CalledProcessError:
+        print("Error: docc merge failed")
+        return [], ["combined-merge"]
+
+    try:
+        transform_static_hosting(combined_output, version, docc_cmd)
+    except subprocess.CalledProcessError:
+        print("Error: docc process-archive transform-for-static-hosting failed")
+        return ["combined-merge"], ["static-hosting-transform"]
+
+    return ["combined-merge", "static-hosting-transform"], []
+
+
 def write_manifest(output_dir, version, entries):
     """Write build-manifest.json to the output directory."""
     manifest = {
@@ -752,11 +878,15 @@ def main():
     workspace = Path(args.workspace) if args.workspace else root_dir / ".workspace"
 
     check_prerequisites()
-    swiftly_cmd = find_swiftly()
-    swift_cmd = find_swift_command()
-    docc_cmd = find_docc_command()
-    if swiftly_cmd:
+    tools = discover_tools()
+    active_swift_version = get_active_swift_version()
+    if tools.swiftly:
         print("swiftly detected — swift and docc invocations will honor .swift-version files.")
+    if active_swift_version:
+        print(
+            f"Active swift toolchain: "
+            f"{active_swift_version[0]}.{active_swift_version[1]}"
+        )
 
     # Validate common template files exist
     for tmpl in TEMPLATE_FILES:
@@ -776,7 +906,13 @@ def main():
         print(f"Error: sources.json is not valid JSON: {e}")
         sys.exit(1)
 
-    validate_sources(config)
+    validate_errors = validate_sources(config)
+    if validate_errors:
+        for e in validate_errors:
+            print(f"Validation error: {e}")
+        print("\nFix the errors in sources.json before continuing.")
+        sys.exit(1)
+    print(f"Validated {len(config['sources'])} source entries.")
 
     version = config["version"]
     sources = config["sources"]
@@ -809,42 +945,37 @@ def main():
     archive_sources = [s for s in sources if s["type"] == "archive"]
     other_sources = [s for s in sources if s["type"] != "archive"]
 
-    for source in archive_sources:
-        source_id = source["id"]
-        if args.only and source_id != args.only:
-            continue
+    def attempt_build(source, fatal=(), recoverable=()):
+        """Run build_source for one entry, sorting exceptions by severity.
+
+        `fatal` exceptions print and sys.exit(1). `recoverable` exceptions are
+        logged and recorded in `failed`. Anything else propagates uncaught.
+        """
+        sid = source["id"]
+        if args.only and sid != args.only:
+            return
         try:
-            archives, manifest_entry = build_source(
+            archives, entry = build_source(
                 source, root_dir, workspace, common_dir,
-                temp_archive_dir, docc_cmd, env,
-                swift_cmd=swift_cmd, swiftly_cmd=swiftly_cmd,
+                temp_archive_dir, tools.docc, env,
+                swift_cmd=tools.swift, swiftly_cmd=tools.swiftly,
+                active_swift_version=active_swift_version,
             )
-        except ArchiveFetchError as e:
+        except fatal as e:
             print(f"Fatal: {e}")
             sys.exit(1)
-        succeeded.append(source_id)
+        except recoverable as e:
+            print(f"Error building {sid}: {e}")
+            failed.append(sid)
+            return
+        succeeded.append(sid)
         all_archives.extend(archives)
-        manifest_entries.append(manifest_entry)
+        manifest_entries.append(entry)
 
+    for source in archive_sources:
+        attempt_build(source, fatal=(ArchiveFetchError,))
     for source in other_sources:
-        source_id = source["id"]
-
-        # Filter if --only is set
-        if args.only and source_id != args.only:
-            continue
-
-        try:
-            archives, manifest_entry = build_source(
-                source, root_dir, workspace, common_dir,
-                temp_archive_dir, docc_cmd, env,
-                swift_cmd=swift_cmd, swiftly_cmd=swiftly_cmd,
-            )
-            succeeded.append(source_id)
-            all_archives.extend(archives)
-            manifest_entries.append(manifest_entry)
-        except Exception as e:
-            print(f"Error building {source_id}: {e}")
-            failed.append(source_id)
+        attempt_build(source, recoverable=(Exception,))
 
     # When --only is used, copy the single source's archive to output directly
     if args.only and all_archives:
@@ -857,43 +988,11 @@ def main():
 
     # Merge all archives — only when building everything (not --only)
     if all_archives and not args.only:
-        print()
-        print("=" * 40)
-        print("Merging combined documentation archive")
-        print("=" * 40)
-
-        if failed:
-            print("Error: cannot merge — the following sources failed to build:")
-            for fid in failed:
-                print(f"  - {fid}")
-            print("Skipping merge step.")
-            failed.append("combined-merge")
-        elif not docc_cmd:
-            print("Error: 'docc' tool not found, cannot merge archives")
-            failed.append("combined-merge")
-        else:
-            # Verify every expected archive exists on disk
-            missing = [a for a in all_archives if not a.is_dir()]
-            if missing:
-                print("Error: the following expected archives are missing:")
-                for ma in missing:
-                    print(f"  - {ma}")
-                failed.append("combined-merge")
-            else:
-                combined_output = output_dir / f"{version}"
-                try:
-                    merge_archives(all_archives, combined_output, docc_cmd)
-                    succeeded.append("combined-merge")
-                except subprocess.CalledProcessError:
-                    print("Error: docc merge failed")
-                    failed.append("combined-merge")
-                else:
-                    try:
-                        transform_static_hosting(combined_output, version, docc_cmd)
-                        succeeded.append("static-hosting-transform")
-                    except subprocess.CalledProcessError:
-                        print("Error: docc process-archive transform-for-static-hosting failed")
-                        failed.append("static-hosting-transform")
+        s_steps, f_steps = _finalize_combined_archive(
+            all_archives, output_dir, version, tools.docc, failed
+        )
+        succeeded.extend(s_steps)
+        failed.extend(f_steps)
 
     # Clean up intermediate archives
     if not args.only and temp_archive_dir.exists():

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -20,8 +20,20 @@ import os
 import shutil
 import subprocess
 import sys
+import tarfile
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+
+
+class ArchiveFetchError(Exception):
+    """Fatal failure fetching or extracting an archive source.
+
+    Raised by fetch_archive() when a download, extraction, or archive
+    resolution step fails. Propagated by main() to abort the entire build,
+    rather than being collected into the per-source failure list.
+    """
 
 
 # Common DocC build flags applied to all documentation builds
@@ -123,9 +135,10 @@ def validate_sources(config):
         entry_type = entry.get("type", "")
         if not entry_type:
             errors.append(f"{label} is missing 'type'")
-        elif entry_type not in ("local", "git"):
+        elif entry_type not in ("local", "git", "archive"):
             errors.append(
-                f"{label} has unknown type '{entry_type}' (expected 'local' or 'git')"
+                f"{label} has unknown type '{entry_type}' "
+                "(expected 'local', 'git', or 'archive')"
             )
 
         if entry_type == "local" and not entry.get("path"):
@@ -137,16 +150,50 @@ def validate_sources(config):
         if entry_type == "git" and not entry.get("ref"):
             errors.append(f"{label} is type 'git' but missing 'ref'")
 
-        has_targets = "targets" in entry
-        has_docc_catalog = "docc_catalog" in entry
-
-        if not has_targets and not has_docc_catalog:
-            errors.append(f"{label} must have either 'targets' or 'docc_catalog'")
-
-        if has_targets and has_docc_catalog:
-            errors.append(
-                f"{label} has both 'targets' and 'docc_catalog' (they are mutually exclusive)"
+        if entry_type == "archive":
+            if not entry.get("url"):
+                errors.append(f"{label} is type 'archive' but missing 'url'")
+            docc_archive_name = entry.get("docc_archive_name", "")
+            if not docc_archive_name:
+                errors.append(
+                    f"{label} is type 'archive' but missing 'docc_archive_name'"
+                )
+            elif not docc_archive_name.endswith(".doccarchive"):
+                errors.append(
+                    f"{label} 'docc_archive_name' must end with '.doccarchive' "
+                    f"(got '{docc_archive_name}')"
+                )
+            archive_format = entry.get("format", "tar.gz")
+            if archive_format != "tar.gz":
+                errors.append(
+                    f"{label} has unsupported 'format' '{archive_format}' "
+                    "(only 'tar.gz' is supported)"
+                )
+            disallowed_for_archive = (
+                "targets", "docc_catalog", "path", "repo", "ref",
+                "preflight", "add_docc_plugin", "extra_flags",
             )
+            for field in disallowed_for_archive:
+                if field in entry:
+                    errors.append(
+                        f"{label} is type 'archive' but has '{field}' "
+                        "(not allowed for archive sources)"
+                    )
+
+        if entry_type in ("local", "git"):
+            has_targets = "targets" in entry
+            has_docc_catalog = "docc_catalog" in entry
+
+            if not has_targets and not has_docc_catalog:
+                errors.append(
+                    f"{label} must have either 'targets' or 'docc_catalog'"
+                )
+
+            if has_targets and has_docc_catalog:
+                errors.append(
+                    f"{label} has both 'targets' and 'docc_catalog' "
+                    "(they are mutually exclusive)"
+                )
 
         if entry.get("add_docc_plugin") and entry_type != "git":
             errors.append(f"{label} has 'add_docc_plugin' but is not type 'git'")
@@ -210,6 +257,54 @@ def clone_or_update(source, workspace, ref):
         )
 
     return source_dir
+
+
+def fetch_archive(source, workspace):
+    """Download and extract a pre-built .doccarchive from a URL.
+
+    Always re-downloads (no caching). Returns the Path to the extracted
+    .doccarchive directory. Raises ArchiveFetchError on any failure so the
+    caller can abort the whole build.
+    """
+    source_id = source["id"]
+    url = source["url"]
+    docc_archive_name = source["docc_archive_name"]
+
+    download_dir = workspace / "_downloads" / source_id
+    if download_dir.exists():
+        shutil.rmtree(str(download_dir))
+    download_dir.mkdir(parents=True)
+
+    filename = Path(url).name or f"{source_id}.tar.gz"
+    download_path = download_dir / filename
+    extract_dir = download_dir / "extracted"
+    extract_dir.mkdir()
+
+    print(f"Downloading {url}...")
+    try:
+        urllib.request.urlretrieve(url, str(download_path))
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
+        raise ArchiveFetchError(
+            f"failed to download archive for '{source_id}' from {url}: {e}"
+        ) from e
+
+    print(f"Extracting to {extract_dir}...")
+    try:
+        with tarfile.open(str(download_path), "r:gz") as tar:
+            tar.extractall(path=str(extract_dir), filter="data")
+    except (tarfile.TarError, OSError, ValueError) as e:
+        raise ArchiveFetchError(
+            f"failed to extract archive for '{source_id}': {e}"
+        ) from e
+
+    matches = [p for p in extract_dir.rglob(docc_archive_name) if p.is_dir()]
+    if not matches:
+        raise ArchiveFetchError(
+            f"'{docc_archive_name}' not found in archive for '{source_id}'"
+        )
+    archive_path = min(matches, key=lambda p: len(p.parts))
+    print(f"Found {docc_archive_name} at {archive_path}")
+    return archive_path
 
 
 def find_docc_catalog_for_target(source_dir, target):
@@ -300,6 +395,24 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
     print("=" * 40)
     print(f"Building: {source_id}")
     print("=" * 40)
+
+    if source_type == "archive":
+        archive_path = fetch_archive(source, workspace)
+        dest = temp_archive_dir / f"{source_id}.doccarchive"
+        if dest.exists():
+            shutil.rmtree(str(dest))
+        shutil.copytree(str(archive_path), str(dest))
+        print(f"Copied {archive_path} -> {dest}")
+
+        manifest_entry = {
+            "id": source_id,
+            "type": "archive",
+            "ref": source.get("version_label", ""),
+            "commit": "",
+            "url": source["url"],
+        }
+        print(f"Done: {source_id}")
+        return [dest], manifest_entry
 
     # Resolve source directory
     if source_type == "local":
@@ -514,7 +627,28 @@ def main():
     all_archives = []
     manifest_entries = []
 
-    for source in sources:
+    # Preflight: fetch archive-type sources first so network or extraction
+    # failures abort the run before any slow git clones or swift builds.
+    archive_sources = [s for s in sources if s["type"] == "archive"]
+    other_sources = [s for s in sources if s["type"] != "archive"]
+
+    for source in archive_sources:
+        source_id = source["id"]
+        if args.only and source_id != args.only:
+            continue
+        try:
+            archives, manifest_entry = build_source(
+                source, root_dir, workspace, common_dir,
+                temp_archive_dir, docc_cmd, env,
+            )
+        except ArchiveFetchError as e:
+            print(f"Fatal: {e}")
+            sys.exit(1)
+        succeeded.append(source_id)
+        all_archives.extend(archives)
+        manifest_entries.append(manifest_entry)
+
+    for source in other_sources:
         source_id = source["id"]
 
         # Filter if --only is set

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -23,6 +23,7 @@ import sys
 import tarfile
 import urllib.error
 import urllib.request
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -164,10 +165,10 @@ def validate_sources(config):
                     f"(got '{docc_archive_name}')"
                 )
             archive_format = entry.get("format", "tar.gz")
-            if archive_format != "tar.gz":
+            if archive_format not in ("tar.gz", "zip"):
                 errors.append(
                     f"{label} has unsupported 'format' '{archive_format}' "
-                    "(only 'tar.gz' is supported)"
+                    "(supported: 'tar.gz', 'zip')"
                 )
             disallowed_for_archive = (
                 "targets", "docc_catalog", "path", "repo", "ref",
@@ -269,13 +270,14 @@ def fetch_archive(source, workspace):
     source_id = source["id"]
     url = source["url"]
     docc_archive_name = source["docc_archive_name"]
+    archive_format = source.get("format", "tar.gz")
 
     download_dir = workspace / "_downloads" / source_id
     if download_dir.exists():
         shutil.rmtree(str(download_dir))
     download_dir.mkdir(parents=True)
 
-    filename = Path(url).name or f"{source_id}.tar.gz"
+    filename = Path(url).name or f"{source_id}.{archive_format}"
     download_path = download_dir / filename
     extract_dir = download_dir / "extracted"
     extract_dir.mkdir()
@@ -290,9 +292,13 @@ def fetch_archive(source, workspace):
 
     print(f"Extracting to {extract_dir}...")
     try:
-        with tarfile.open(str(download_path), "r:gz") as tar:
-            tar.extractall(path=str(extract_dir), filter="data")
-    except (tarfile.TarError, OSError, ValueError) as e:
+        if archive_format == "zip":
+            with zipfile.ZipFile(str(download_path)) as zf:
+                zf.extractall(path=str(extract_dir))
+        else:
+            with tarfile.open(str(download_path), "r:gz") as tar:
+                tar.extractall(path=str(extract_dir), filter="data")
+    except (tarfile.TarError, zipfile.BadZipFile, OSError, ValueError) as e:
         raise ArchiveFetchError(
             f"failed to extract archive for '{source_id}': {e}"
         ) from e

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -17,6 +17,7 @@
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,8 @@ import urllib.request
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+from strip_availability import strip_archive
 
 
 class ArchiveFetchError(Exception):
@@ -84,11 +87,15 @@ def check_prerequisites():
 
 
 def find_docc_command():
-    """Find the docc tool — prefer xcrun on macOS, fall back to PATH.
+    """Find the docc tool — prefer swiftly proxy, then xcrun on macOS, then PATH.
 
-    Returns a list of command components (e.g. ["xcrun", "docc"] or ["docc"]),
-    or an empty list if docc is not found.
+    Routing through swiftly when available ensures the docc invocation honors
+    any `.swift-version` file in the working directory.
+    Returns a list of command components (e.g. ["swiftly", "run", "docc"]
+    or ["xcrun", "docc"] or ["docc"]), or an empty list if docc is not found.
     """
+    if shutil.which("swiftly"):
+        return ["swiftly", "run", "docc"]
     if shutil.which("xcrun"):
         try:
             subprocess.run(
@@ -102,6 +109,74 @@ def find_docc_command():
     if shutil.which("docc"):
         return ["docc"]
     return []
+
+
+def find_swiftly():
+    """Return ['swiftly'] if swiftly is on PATH, else []."""
+    if shutil.which("swiftly"):
+        return ["swiftly"]
+    return []
+
+
+def find_swift_command():
+    """Find swift — prefer swiftly proxy so .swift-version files are honored."""
+    if shutil.which("swiftly"):
+        return ["swiftly", "run", "swift"]
+    if shutil.which("swift"):
+        return ["swift"]
+    return []
+
+
+def ensure_toolchain_installed(source_dir, swiftly_cmd):
+    """Pre-install the toolchain pinned by `.swift-version`, if any.
+
+    Walks no directories — only checks for `.swift-version` directly in
+    source_dir. swiftly itself walks parents at command-resolution time, but
+    we only auto-install when the source root explicitly pins a version.
+    No-op when swiftly is unavailable or no version file is present.
+    """
+    if not swiftly_cmd:
+        return
+    if not (source_dir / ".swift-version").is_file():
+        return
+    print(f"Ensuring pinned toolchain is installed (swiftly install)...")
+    subprocess.run(
+        swiftly_cmd + ["install", "--assume-yes"],
+        cwd=str(source_dir),
+        check=True,
+    )
+
+
+_TOOLS_VERSION_RE = re.compile(
+    r"^//\s*swift-tools-version\s*:\s*(\d+(?:\.\d+){0,2})"
+)
+
+
+def read_swift_tools_version(source_dir):
+    """Parse the `// swift-tools-version:` declaration in Package.swift.
+
+    Returns the version as a major.minor string (e.g. "6.3" or "5.10"),
+    stripping any patch component. Returns None if Package.swift is missing,
+    empty, or doesn't have a recognizable tools-version line.
+
+    Used as a fallback selector for swiftly when a source has no
+    `.swift-version` file but its Package.swift declares a minimum toolchain.
+    """
+    package_swift = Path(source_dir) / "Package.swift"
+    if not package_swift.is_file():
+        return None
+    try:
+        text = package_swift.read_text()
+    except OSError:
+        return None
+    if not text:
+        return None
+    first_line = text.splitlines()[0]
+    m = _TOOLS_VERSION_RE.match(first_line)
+    if not m:
+        return None
+    parts = m.group(1).split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else parts[0]
 
 
 def validate_sources(config):
@@ -170,6 +245,13 @@ def validate_sources(config):
                     f"{label} has unsupported 'format' '{archive_format}' "
                     "(supported: 'tar.gz', 'zip')"
                 )
+            if "strip_availability" in entry and not isinstance(
+                entry["strip_availability"], bool
+            ):
+                errors.append(
+                    f"{label} 'strip_availability' must be a boolean "
+                    f"(got {type(entry['strip_availability']).__name__})"
+                )
             disallowed_for_archive = (
                 "targets", "docc_catalog", "path", "repo", "ref",
                 "preflight", "add_docc_plugin", "extra_flags",
@@ -194,6 +276,12 @@ def validate_sources(config):
                 errors.append(
                     f"{label} has both 'targets' and 'docc_catalog' "
                     "(they are mutually exclusive)"
+                )
+
+            if "strip_availability" in entry:
+                errors.append(
+                    f"{label} has 'strip_availability' but is not type "
+                    "'archive' (only allowed on archive sources)"
                 )
 
         if entry.get("add_docc_plugin") and entry_type != "git":
@@ -313,7 +401,7 @@ def fetch_archive(source, workspace):
     return archive_path
 
 
-def find_docc_catalog_for_target(source_dir, target):
+def find_docc_catalog_for_target(source_dir, target, swift_cmd):
     """Discover the .docc catalog directory for a Swift package target.
 
     Uses `swift package describe --type json` to find the target's source path,
@@ -321,7 +409,7 @@ def find_docc_catalog_for_target(source_dir, target):
     """
     try:
         result = subprocess.run(
-            ["swift", "package", "describe", "--type", "json"],
+            swift_cmd + ["package", "describe", "--type", "json"],
             cwd=str(source_dir),
             capture_output=True,
             text=True,
@@ -367,7 +455,7 @@ def find_doccarchive(search_dir, target):
     return None
 
 
-def add_docc_plugin(source_dir):
+def add_docc_plugin(source_dir, swift_cmd):
     """Inject swift-docc-plugin dependency if not already present."""
     package_swift = source_dir / "Package.swift"
     if "swift-docc-plugin" in package_swift.read_text():
@@ -375,8 +463,8 @@ def add_docc_plugin(source_dir):
         return
     print("Adding swift-docc-plugin dependency...")
     subprocess.run(
-        [
-            "swift", "package", "add-dependency",
+        swift_cmd + [
+            "package", "add-dependency",
             "https://github.com/swiftlang/swift-docc-plugin",
             "--from", "1.1.0",
         ],
@@ -385,12 +473,17 @@ def add_docc_plugin(source_dir):
     )
 
 
-def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc_cmd, env):
+def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc_cmd, env, swift_cmd=None, swiftly_cmd=None):
     """Build a single source entry.
 
     Returns a tuple of (list_of_archive_paths, manifest_entry) on success,
     or raises an exception on failure.
     """
+    if swift_cmd is None:
+        swift_cmd = ["swift"]
+    if swiftly_cmd is None:
+        swiftly_cmd = []
+
     source_id = source["id"]
     source_type = source["type"]
     docc_catalog = source.get("docc_catalog", "")
@@ -409,6 +502,14 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
             shutil.rmtree(str(dest))
         shutil.copytree(str(archive_path), str(dest))
         print(f"Copied {archive_path} -> {dest}")
+
+        if source.get("strip_availability"):
+            print(f"Stripping availability from {dest}...")
+            scanned, modified, removed = strip_archive(dest)
+            print(
+                f"  scanned {scanned} files; modified {modified}; "
+                f"removed {removed} 'platforms' keys"
+            )
 
         manifest_entry = {
             "id": source_id,
@@ -431,6 +532,37 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
     else:
         raise RuntimeError(f"unknown type '{source_type}'")
 
+    # If the source pins a specific Swift toolchain, ensure it's installed
+    # before any swift/docc command runs against it.
+    ensure_toolchain_installed(source_dir, swiftly_cmd)
+
+    # Fallback: if no `.swift-version` exists but Package.swift declares a
+    # minimum tools-version, route swift/docc through swiftly with that
+    # version as a `+selector`. This lets repos that pin via Package.swift
+    # (e.g. swift-testing) build without manual swiftly setup.
+    if (
+        swiftly_cmd
+        and not (source_dir / ".swift-version").is_file()
+    ):
+        tools_version = read_swift_tools_version(source_dir)
+        if tools_version:
+            print(
+                f"Package.swift requires swift-tools-version {tools_version}; "
+                f"using `swiftly +{tools_version}`."
+            )
+            try:
+                subprocess.run(
+                    swiftly_cmd + ["install", tools_version, "--assume-yes"],
+                    check=True,
+                )
+            except subprocess.CalledProcessError as e:
+                print(
+                    f"  Note: `swiftly install {tools_version}` failed ({e}); "
+                    "continuing with default toolchain."
+                )
+            else:
+                swift_cmd = swift_cmd + [f"+{tools_version}"]
+
     # Run preflight command if configured
     preflight = source.get("preflight", "")
     if preflight:
@@ -444,14 +576,14 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
 
     # Inject swift-docc-plugin if requested
     if source.get("add_docc_plugin"):
-        add_docc_plugin(source_dir)
+        add_docc_plugin(source_dir, swift_cmd)
 
     archives = []
 
     if targets:
         # Install templates into each target's .docc catalog
         for target in targets:
-            catalog_dir = find_docc_catalog_for_target(source_dir, target)
+            catalog_dir = find_docc_catalog_for_target(source_dir, target, swift_cmd)
             if catalog_dir:
                 install_templates(catalog_dir, common_dir, f"{source_id}/{target}")
             else:
@@ -463,8 +595,8 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
         # Build each target via swift package
         for target in targets:
             print(f"Building target: {target}")
-            cmd = [
-                "swift", "package", "generate-documentation",
+            cmd = swift_cmd + [
+                "package", "generate-documentation",
                 "--target", target,
             ] + DOCC_BUILD_FLAGS + extra_flags
             subprocess.run(cmd, cwd=str(source_dir), check=True, env=env)
@@ -561,6 +693,41 @@ def merge_archives(archives, output_path, docc_cmd):
     print(f"Combined archive: {output_path}")
 
 
+def transform_static_hosting(archive_path, hosting_base_path, docc_cmd):
+    """Bake a hosting base path into a finished .doccarchive in place.
+
+    Runs `docc process-archive transform-for-static-hosting` on the archive
+    so its router and links resolve under /<hosting_base_path>/, then swaps
+    the transformed archive into the original location. On failure, leaves
+    the original archive untouched.
+    """
+    if not docc_cmd:
+        raise RuntimeError("'docc' tool not found (tried xcrun and PATH)")
+
+    archive_path = Path(archive_path)
+    transformed = archive_path.parent / f".{archive_path.name}.transforming"
+    if transformed.exists():
+        shutil.rmtree(str(transformed))
+
+    print(f"Applying hosting base path '{hosting_base_path}' to {archive_path.name}...")
+    cmd = docc_cmd + [
+        "process-archive", "transform-for-static-hosting",
+        str(archive_path),
+        "--hosting-base-path", hosting_base_path,
+        "--output-path", str(transformed),
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        if transformed.exists():
+            shutil.rmtree(str(transformed))
+        raise
+
+    shutil.rmtree(str(archive_path))
+    shutil.move(str(transformed), str(archive_path))
+    print(f"Transformed archive: {archive_path}")
+
+
 def write_manifest(output_dir, version, entries):
     """Write build-manifest.json to the output directory."""
     manifest = {
@@ -585,7 +752,11 @@ def main():
     workspace = Path(args.workspace) if args.workspace else root_dir / ".workspace"
 
     check_prerequisites()
+    swiftly_cmd = find_swiftly()
+    swift_cmd = find_swift_command()
     docc_cmd = find_docc_command()
+    if swiftly_cmd:
+        print("swiftly detected — swift and docc invocations will honor .swift-version files.")
 
     # Validate common template files exist
     for tmpl in TEMPLATE_FILES:
@@ -646,6 +817,7 @@ def main():
             archives, manifest_entry = build_source(
                 source, root_dir, workspace, common_dir,
                 temp_archive_dir, docc_cmd, env,
+                swift_cmd=swift_cmd, swiftly_cmd=swiftly_cmd,
             )
         except ArchiveFetchError as e:
             print(f"Fatal: {e}")
@@ -665,6 +837,7 @@ def main():
             archives, manifest_entry = build_source(
                 source, root_dir, workspace, common_dir,
                 temp_archive_dir, docc_cmd, env,
+                swift_cmd=swift_cmd, swiftly_cmd=swiftly_cmd,
             )
             succeeded.append(source_id)
             all_archives.extend(archives)
@@ -714,6 +887,13 @@ def main():
                 except subprocess.CalledProcessError:
                     print("Error: docc merge failed")
                     failed.append("combined-merge")
+                else:
+                    try:
+                        transform_static_hosting(combined_output, version, docc_cmd)
+                        succeeded.append("static-hosting-transform")
+                    except subprocess.CalledProcessError:
+                        print("Error: docc process-archive transform-for-static-hosting failed")
+                        failed.append("static-hosting-transform")
 
     # Clean up intermediate archives
     if not args.only and temp_archive_dir.exists():

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -267,7 +267,7 @@ def validate_sources(config):
 
     Pure check — does not print or exit. The caller decides how to surface
     errors. Returns early after structural problems (missing top-level keys,
-    `sources` not a list) so per-entry validation only runs against a sane
+    `sources` not a list) so per-entry validation only runs against a validated
     shape.
     """
     errors = []

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -17,18 +17,6 @@
       "docc_catalog": "Guide.docc"
     },
     {
-      "id": "api-guidelines",
-      "type": "local",
-      "path": "api-guidelines",
-      "targets": ["APIGuidelines"]
-    },
-    {
-      "id": "language-guides",
-      "type": "local",
-      "path": "language-guides",
-      "targets": ["LanguageGuides"]
-    },
-    {
       "id": "compiler-diagnostics",
       "type": "git",
       "repo": "https://github.com/swiftlang/swift.git",
@@ -111,6 +99,13 @@
       "repo": "https://github.com/swiftlang/swiftly.git",
       "ref": "main",
       "targets": ["SwiftlyDocs"]
+    },
+    {
+      "id": "swift-stdlib",
+      "type": "archive",
+      "url": "https://ci.swift.org/job/build-stdlib-docs/36/artifact/*zip*/archive.zip",
+      "format": "zip",
+      "docc_archive_name": "Swift.doccarchive"
     }
   ]
 }

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -14,7 +14,8 @@
       "type": "archive",
       "url": "https://ci.swift.org/job/build-stdlib-docs/36/artifact/*zip*/archive.zip",
       "format": "zip",
-      "docc_archive_name": "Swift.doccarchive"
+      "docc_archive_name": "Swift.doccarchive",
+      "strip_availability": true
     },
     {
       "id": "swift-migration-guide",

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -10,6 +10,13 @@
       "preflight": "bin/generate-grammar"
     },
     {
+      "id": "swift-stdlib",
+      "type": "archive",
+      "url": "https://ci.swift.org/job/build-stdlib-docs/36/artifact/*zip*/archive.zip",
+      "format": "zip",
+      "docc_archive_name": "Swift.doccarchive"
+    },
+    {
       "id": "swift-migration-guide",
       "type": "git",
       "repo": "https://github.com/swiftlang/swift-migration-guide.git",
@@ -23,12 +30,6 @@
       "ref": "main",
       "docc_catalog": "userdocs/diagnostics",
       "extra_flags": ["--allow-arbitrary-catalog-directories"]
-    },
-    {
-      "id": "ecosystem-tools",
-      "type": "local",
-      "path": "ecosystem-tools",
-      "targets": ["EcosystemTools"]
     },
     {
       "id": "swiftpm",
@@ -99,13 +100,6 @@
       "repo": "https://github.com/swiftlang/swiftly.git",
       "ref": "main",
       "targets": ["SwiftlyDocs"]
-    },
-    {
-      "id": "swift-stdlib",
-      "type": "archive",
-      "url": "https://ci.swift.org/job/build-stdlib-docs/36/artifact/*zip*/archive.zip",
-      "format": "zip",
-      "docc_archive_name": "Swift.doccarchive"
     }
   ]
 }

--- a/scripts/strip_availability.py
+++ b/scripts/strip_availability.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 """
 strip-availability.py — Remove platform availability data from a DocC archive.
 

--- a/scripts/strip_availability.py
+++ b/scripts/strip_availability.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+strip-availability.py — Remove platform availability data from a DocC archive.
+
+Walks every JSON file under <archive>/data/ and deletes any "platforms" key it
+finds. In a Swift.doccarchive these only appear in two places:
+
+  - metadata.platforms                          (the iOS/macOS/... badge table
+                                                 on each symbol page)
+  - primaryContentSections[*].declarations[*].platforms
+                                                (per-declaration variant tag,
+                                                 e.g. ["macOS"])
+
+Both are populated by DocC at convert-time from the bundle's
+CDAppleDefaultAvailability Info.plist key plus any compiler-provided
+@available data. Deleting them yields a platform-neutral doc set.
+
+Usage:
+    ./strip-availability.py path/to/Swift.doccarchive
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+TARGET_KEY = "platforms"
+
+
+def strip(node):
+    """Recursively delete every key named TARGET_KEY. Returns count removed."""
+    removed = 0
+    if isinstance(node, dict):
+        if TARGET_KEY in node:
+            del node[TARGET_KEY]
+            removed += 1
+        for v in node.values():
+            removed += strip(v)
+    elif isinstance(node, list):
+        for v in node:
+            removed += strip(v)
+    return removed
+
+
+def process_file(path):
+    with open(path, "rb") as f:
+        data = json.load(f)
+
+    removed = strip(data)
+    if removed == 0:
+        return 0
+
+    dir_ = os.path.dirname(path)
+    fd, tmp = tempfile.mkstemp(prefix=".strip-", dir=dir_)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, separators=(",", ":"), ensure_ascii=False)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+    return removed
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write(f"usage: {sys.argv[0]} <path-to-doccarchive>\n")
+        sys.exit(2)
+
+    archive = os.path.abspath(sys.argv[1])
+    data_dir = os.path.join(archive, "data")
+    if not os.path.isdir(data_dir):
+        sys.stderr.write(
+            f"error: {archive!r} does not look like a .doccarchive "
+            f"(missing data/ directory)\n"
+        )
+        sys.exit(1)
+
+    files_scanned = 0
+    files_modified = 0
+    keys_removed = 0
+
+    for root, _, names in os.walk(data_dir):
+        for name in names:
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(root, name)
+            files_scanned += 1
+            try:
+                removed = process_file(path)
+            except json.JSONDecodeError as e:
+                sys.stderr.write(f"skip (invalid JSON): {path}: {e}\n")
+                continue
+            if removed:
+                files_modified += 1
+                keys_removed += removed
+
+    print(
+        f"scanned {files_scanned} files; "
+        f"modified {files_modified}; "
+        f"removed {keys_removed} 'platforms' keys"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strip_availability.py
+++ b/scripts/strip_availability.py
@@ -71,13 +71,33 @@ def main():
         sys.exit(2)
 
     archive = os.path.abspath(sys.argv[1])
+    try:
+        files_scanned, files_modified, keys_removed = strip_archive(archive)
+    except ValueError as e:
+        sys.stderr.write(f"error: {e}\n")
+        sys.exit(1)
+
+    print(
+        f"scanned {files_scanned} files; "
+        f"modified {files_modified}; "
+        f"removed {keys_removed} 'platforms' keys"
+    )
+
+
+def strip_archive(archive_path):
+    """Strip every 'platforms' key from JSON files under <archive>/data/.
+
+    Returns (files_scanned, files_modified, keys_removed).
+    Raises ValueError if archive_path doesn't look like a .doccarchive
+    (i.e. has no data/ subdirectory).
+    """
+    archive = os.fspath(archive_path)
     data_dir = os.path.join(archive, "data")
     if not os.path.isdir(data_dir):
-        sys.stderr.write(
-            f"error: {archive!r} does not look like a .doccarchive "
-            f"(missing data/ directory)\n"
+        raise ValueError(
+            f"{archive!r} does not look like a .doccarchive "
+            f"(missing data/ directory)"
         )
-        sys.exit(1)
 
     files_scanned = 0
     files_modified = 0
@@ -98,11 +118,7 @@ def main():
                 files_modified += 1
                 keys_removed += removed
 
-    print(
-        f"scanned {files_scanned} files; "
-        f"modified {files_modified}; "
-        f"removed {keys_removed} 'platforms' keys"
-    )
+    return files_scanned, files_modified, keys_removed
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -14,12 +14,10 @@
 ##===----------------------------------------------------------------------===##
 """Tests for build_docs.py.
 
-Run from the scripts/ directory (or repo root) with:
+Run from the scripts/ directory (or repository root) with:
     python3 -m unittest scripts/test_build_docs.py
 """
 
-import contextlib
-import io
 import json
 import subprocess
 import sys
@@ -36,15 +34,13 @@ import strip_availability  # noqa: E402
 
 
 def _validate(config):
-    """Call validate_sources with stdout suppressed. Returns None on success,
-    or the captured stdout text on SystemExit."""
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        try:
-            build_docs.validate_sources(config)
-        except SystemExit:
-            return buf.getvalue()
-    return None
+    """Run validate_sources and return joined error text, or None if valid.
+
+    Joining preserves the assertion shape used by existing tests
+    (assertIn("url", output)) without needing per-error matching.
+    """
+    errors = build_docs.validate_sources(config)
+    return "\n".join(errors) if errors else None
 
 
 def _wrap(entry):
@@ -642,43 +638,56 @@ class TransformStaticHosting(unittest.TestCase):
                 build_docs.transform_static_hosting(archive, "main", [])
 
 
-class FindSwiftly(unittest.TestCase):
-    def test_returns_command_when_on_path(self):
-        with mock.patch.object(build_docs.shutil, "which", return_value="/usr/local/bin/swiftly"):
-            self.assertEqual(build_docs.find_swiftly(), ["swiftly"])
+class DiscoverTools(unittest.TestCase):
+    def test_swiftly_present_routes_everything_through_swiftly(self):
+        with mock.patch.object(build_docs.shutil, "which") as which:
+            which.side_effect = lambda name: f"/fake/{name}" if name == "swiftly" else None
+            tools = build_docs.discover_tools()
+        self.assertEqual(tools.swiftly, ["swiftly"])
+        self.assertEqual(tools.swift, ["swiftly", "run", "swift"])
+        self.assertEqual(tools.docc, ["swiftly", "run", "docc"])
 
-    def test_returns_empty_when_absent(self):
+    def test_no_swiftly_uses_direct_swift(self):
+        present = {"swift": "/usr/bin/swift"}
+        with mock.patch.object(build_docs.shutil, "which", side_effect=present.get):
+            tools = build_docs.discover_tools()
+        self.assertEqual(tools.swiftly, [])
+        self.assertEqual(tools.swift, ["swift"])
+        self.assertEqual(tools.docc, [])
+
+    def test_xcrun_finds_docc_when_no_swiftly(self):
+        present = {"swift": "/usr/bin/swift", "xcrun": "/usr/bin/xcrun"}
+
+        def fake_run(cmd, **kw):
+            self.assertEqual(cmd[:2], ["xcrun", "--find"])
+            return subprocess.CompletedProcess(cmd, 0, stdout="/path/docc\n", stderr="")
+
+        with mock.patch.object(build_docs.shutil, "which", side_effect=present.get):
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                tools = build_docs.discover_tools()
+        self.assertEqual(tools.docc, ["xcrun", "docc"])
+
+    def test_falls_back_to_path_docc_when_xcrun_fails(self):
+        present = {
+            "swift": "/usr/bin/swift",
+            "xcrun": "/usr/bin/xcrun",
+            "docc": "/usr/local/bin/docc",
+        }
+
+        def fake_run(cmd, **kw):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with mock.patch.object(build_docs.shutil, "which", side_effect=present.get):
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                tools = build_docs.discover_tools()
+        self.assertEqual(tools.docc, ["docc"])
+
+    def test_nothing_found_returns_empty_lists(self):
         with mock.patch.object(build_docs.shutil, "which", return_value=None):
-            self.assertEqual(build_docs.find_swiftly(), [])
-
-
-class FindSwiftCommand(unittest.TestCase):
-    def test_prefers_swiftly_when_available(self):
-        def fake_which(name):
-            return f"/fake/{name}" if name == "swiftly" else None
-        with mock.patch.object(build_docs.shutil, "which", side_effect=fake_which):
-            self.assertEqual(build_docs.find_swift_command(), ["swiftly", "run", "swift"])
-
-    def test_falls_back_to_direct_swift(self):
-        def fake_which(name):
-            return "/usr/bin/swift" if name == "swift" else None
-        with mock.patch.object(build_docs.shutil, "which", side_effect=fake_which):
-            self.assertEqual(build_docs.find_swift_command(), ["swift"])
-
-    def test_returns_empty_when_neither_present(self):
-        with mock.patch.object(build_docs.shutil, "which", return_value=None):
-            self.assertEqual(build_docs.find_swift_command(), [])
-
-
-class FindDoccCommandPrefersSwiftly(unittest.TestCase):
-    def test_prefers_swiftly_when_available(self):
-        def fake_which(name):
-            return f"/fake/{name}" if name == "swiftly" else None
-        with mock.patch.object(build_docs.shutil, "which", side_effect=fake_which):
-            self.assertEqual(
-                build_docs.find_docc_command(),
-                ["swiftly", "run", "docc"],
-            )
+            tools = build_docs.discover_tools()
+        self.assertEqual(tools.swiftly, [])
+        self.assertEqual(tools.swift, [])
+        self.assertEqual(tools.docc, [])
 
 
 class EnsureToolchainInstalled(unittest.TestCase):
@@ -731,6 +740,203 @@ class EnsureToolchainInstalled(unittest.TestCase):
             self.assertEqual(calls, [])
 
 
+class GetActiveSwiftVersion(unittest.TestCase):
+    def test_parses_apple_swift_format(self):
+        stdout = (
+            "Apple Swift version 6.1.2 (swiftlang-6.1.2.0.55 "
+            "clang-1700.0.13.5)\n"
+            "Target: arm64-apple-macosx15.0\n"
+        )
+        result = subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
+        with mock.patch.object(build_docs.shutil, "which", return_value="/usr/bin/swift"):
+            with mock.patch.object(build_docs.subprocess, "run", return_value=result):
+                self.assertEqual(build_docs.get_active_swift_version(), (6, 1))
+
+    def test_parses_oss_swift_format(self):
+        stdout = (
+            "Swift version 5.10 (swift-5.10-RELEASE)\n"
+            "Target: x86_64-unknown-linux-gnu\n"
+        )
+        result = subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
+        with mock.patch.object(build_docs.shutil, "which", return_value="/usr/bin/swift"):
+            with mock.patch.object(build_docs.subprocess, "run", return_value=result):
+                self.assertEqual(build_docs.get_active_swift_version(), (5, 10))
+
+    def test_returns_none_when_swift_missing(self):
+        with mock.patch.object(build_docs.shutil, "which", return_value=None):
+            self.assertIsNone(build_docs.get_active_swift_version())
+
+    def test_returns_none_when_output_unparseable(self):
+        result = subprocess.CompletedProcess([], 0, stdout="garbage\n", stderr="")
+        with mock.patch.object(build_docs.shutil, "which", return_value="/usr/bin/swift"):
+            with mock.patch.object(build_docs.subprocess, "run", return_value=result):
+                self.assertIsNone(build_docs.get_active_swift_version())
+
+    def test_returns_none_when_swift_invocation_fails(self):
+        def fake_run(*a, **kw):
+            raise subprocess.CalledProcessError(1, a[0])
+
+        with mock.patch.object(build_docs.shutil, "which", return_value="/usr/bin/swift"):
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                self.assertIsNone(build_docs.get_active_swift_version())
+
+
+class SelectSwiftToolchain(unittest.TestCase):
+    def _write_package(self, dir_, tools_version):
+        (Path(dir_) / "Package.swift").write_text(
+            f"// swift-tools-version: {tools_version}\nimport PackageDescription\n"
+        )
+
+    def test_no_swiftly_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "6.3")
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swift"], Path(tmp), [], active_swift_version=(5, 0)
+                )
+            self.assertEqual(result, ["swift"])
+            self.assertEqual(calls, [])
+
+    def test_swift_version_file_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "6.3")
+            (Path(tmp) / ".swift-version").write_text("6.3\n")
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=(5, 0),
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift"])
+            self.assertEqual(calls, [])
+
+    def test_no_tools_version_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=(6, 1),
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift"])
+            self.assertEqual(calls, [])
+
+    def test_active_equal_to_required_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "6.1")
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=(6, 1),
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift"])
+            self.assertEqual(calls, [])
+
+    def test_active_newer_than_required_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "5.10")
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=(6, 1),
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift"])
+            self.assertEqual(calls, [])
+
+    def test_active_older_installs_and_pins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "6.3")
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=(6, 1),
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift", "+6.3"])
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][:3], ["swiftly", "install", "6.3"])
+            self.assertIn("--assume-yes", calls[0])
+
+    def test_active_unknown_installs_and_pins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "6.3")
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=None,
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift", "+6.3"])
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][:3], ["swiftly", "install", "6.3"])
+
+    def test_install_failure_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "6.3")
+
+            def fake_run(cmd, **kw):
+                raise subprocess.CalledProcessError(1, cmd)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                result = build_docs.select_swift_toolchain(
+                    ["swiftly", "run", "swift"],
+                    Path(tmp),
+                    ["swiftly"],
+                    active_swift_version=(6, 1),
+                )
+            self.assertEqual(result, ["swiftly", "run", "swift"])
+
+
 class ReadSwiftToolsVersion(unittest.TestCase):
     def _write_package(self, dir_, first_line):
         pkg = Path(dir_) / "Package.swift"
@@ -770,6 +976,153 @@ class ReadSwiftToolsVersion(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             (Path(tmp) / "Package.swift").write_text("")
             self.assertIsNone(build_docs.read_swift_tools_version(Path(tmp)))
+
+
+class CollectGitMetadata(unittest.TestCase):
+    def test_configured_ref_returned_verbatim_with_commit(self):
+        def fake_run(cmd, **kw):
+            self.assertIn("rev-parse", cmd)
+            self.assertIn("HEAD", cmd)
+            self.assertNotIn("--abbrev-ref", cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+
+        with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+            ref, commit = build_docs._collect_git_metadata(
+                Path("/tmp/x"), configured_ref="release/6.1"
+            )
+        self.assertEqual(ref, "release/6.1")
+        self.assertEqual(commit, "abc123")
+
+    def test_configured_ref_kept_when_git_fails(self):
+        def fake_run(cmd, **kw):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+            ref, commit = build_docs._collect_git_metadata(
+                Path("/tmp/x"), configured_ref="main"
+            )
+        self.assertEqual(ref, "main")
+        self.assertEqual(commit, "unknown")
+
+    def test_no_configured_ref_reads_both_from_git(self):
+        outputs = iter([
+            subprocess.CompletedProcess([], 0, stdout="feature-x\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="def456\n", stderr=""),
+        ])
+
+        def fake_run(cmd, **kw):
+            return next(outputs)
+
+        with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+            ref, commit = build_docs._collect_git_metadata(Path("/tmp/x"))
+        self.assertEqual(ref, "feature-x")
+        self.assertEqual(commit, "def456")
+
+    def test_no_configured_ref_returns_unknown_on_git_failure(self):
+        def fake_run(cmd, **kw):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+            ref, commit = build_docs._collect_git_metadata(Path("/tmp/x"))
+        self.assertEqual(ref, "unknown")
+        self.assertEqual(commit, "unknown")
+
+
+class FinalizeCombinedArchive(unittest.TestCase):
+    def test_prior_failures_skip_merge(self):
+        succeeded, failed = build_docs._finalize_combined_archive(
+            [], Path("/tmp"), "main", ["docc"], prior_failed=["foo", "bar"]
+        )
+        self.assertEqual(succeeded, [])
+        self.assertEqual(failed, ["combined-merge"])
+
+    def test_missing_docc_skips_merge(self):
+        succeeded, failed = build_docs._finalize_combined_archive(
+            [], Path("/tmp"), "main", [], prior_failed=[]
+        )
+        self.assertEqual(succeeded, [])
+        self.assertEqual(failed, ["combined-merge"])
+
+    def test_missing_archive_dir_skips_merge(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            ghost = tmp_path / "doesnotexist.doccarchive"
+            succeeded, failed = build_docs._finalize_combined_archive(
+                [ghost], tmp_path, "main", ["docc"], prior_failed=[]
+            )
+        self.assertEqual(succeeded, [])
+        self.assertEqual(failed, ["combined-merge"])
+
+    def test_merge_failure_records_combined_merge_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+
+            def fake_run(cmd, **kw):
+                raise subprocess.CalledProcessError(1, cmd)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                succeeded, failed = build_docs._finalize_combined_archive(
+                    [archive], tmp_path, "main", ["docc"], prior_failed=[]
+                )
+        self.assertEqual(succeeded, [])
+        self.assertEqual(failed, ["combined-merge"])
+
+    def test_transform_failure_records_only_transform(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+            (archive / "index.html").write_text("ok")
+
+            calls = []
+
+            def fake_run(cmd, **kw):
+                calls.append(cmd)
+                # First call is `docc merge`; succeed by creating output dir.
+                if "merge" in cmd:
+                    out_idx = cmd.index("--output-path") + 1
+                    Path(cmd[out_idx]).mkdir(parents=True, exist_ok=True)
+                    return subprocess.CompletedProcess(cmd, 0)
+                # Second call is the transform; fail.
+                raise subprocess.CalledProcessError(1, cmd)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                succeeded, failed = build_docs._finalize_combined_archive(
+                    [archive], tmp_path, "main", ["docc"], prior_failed=[]
+                )
+        self.assertEqual(succeeded, ["combined-merge"])
+        self.assertEqual(failed, ["static-hosting-transform"])
+
+    def test_full_success_records_both_steps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+            (archive / "index.html").write_text("ok")
+
+            def fake_run(cmd, **kw):
+                if "merge" in cmd:
+                    out_idx = cmd.index("--output-path") + 1
+                    out = Path(cmd[out_idx])
+                    out.mkdir(parents=True, exist_ok=True)
+                    (out / "index.html").write_text("merged")
+                    return subprocess.CompletedProcess(cmd, 0)
+                # Transform step: simulate docc producing the transformed
+                # archive at --output-path.
+                out_idx = cmd.index("--output-path") + 1
+                out = Path(cmd[out_idx])
+                out.mkdir(parents=True, exist_ok=True)
+                (out / "index.html").write_text("transformed")
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                succeeded, failed = build_docs._finalize_combined_archive(
+                    [archive], tmp_path, "main", ["docc"], prior_failed=[]
+                )
+        self.assertEqual(succeeded, ["combined-merge", "static-hosting-transform"])
+        self.assertEqual(failed, [])
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1,0 +1,347 @@
+"""Tests for build_docs.py.
+
+Run from the scripts/ directory (or repo root) with:
+    python3 -m unittest scripts/test_build_docs.py
+"""
+
+import contextlib
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import build_docs  # noqa: E402
+
+
+def _validate(config):
+    """Call validate_sources with stdout suppressed. Returns None on success,
+    or the captured stdout text on SystemExit."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        try:
+            build_docs.validate_sources(config)
+        except SystemExit:
+            return buf.getvalue()
+    return None
+
+
+def _wrap(entry):
+    return {"version": "main", "sources": [entry]}
+
+
+class ValidateArchiveType(unittest.TestCase):
+    def test_minimal_valid(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.tar.gz",
+            "docc_archive_name": "Swift.doccarchive",
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_full_valid(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.tar.gz",
+            "docc_archive_name": "Swift.doccarchive",
+            "format": "tar.gz",
+            "version_label": "main",
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_missing_url(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "docc_archive_name": "Swift.doccarchive",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("url", output)
+
+    def test_missing_docc_archive_name(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.tar.gz",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("docc_archive_name", output)
+
+    def test_bad_docc_archive_name_suffix(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/foo.tar.gz",
+            "docc_archive_name": "Swift",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn(".doccarchive", output)
+
+    def test_unsupported_format(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.zip",
+            "docc_archive_name": "Swift.doccarchive",
+            "format": "zip",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("format", output)
+
+    def test_rejects_mutually_exclusive_fields(self):
+        base = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.tar.gz",
+            "docc_archive_name": "Swift.doccarchive",
+        }
+        disallowed = {
+            "targets": ["Foo"],
+            "docc_catalog": "Foo.docc",
+            "path": "some/path",
+            "repo": "https://example.com/repo.git",
+            "ref": "main",
+            "preflight": "echo hi",
+            "add_docc_plugin": True,
+            "extra_flags": ["--foo"],
+        }
+        for field, value in disallowed.items():
+            with self.subTest(field=field):
+                entry = dict(base)
+                entry[field] = value
+                output = _validate(_wrap(entry))
+                self.assertIsNotNone(
+                    output, f"expected rejection when '{field}' is set"
+                )
+                self.assertIn(field, output)
+
+    def test_unknown_type_still_rejected(self):
+        entry = {
+            "id": "stdlib",
+            "type": "remote",
+            "url": "https://example.com/foo.tar.gz",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("unknown type", output)
+
+
+class ValidateExistingTypesStillWork(unittest.TestCase):
+    """Regression: make sure local and git validation is unchanged."""
+
+    def test_local_valid(self):
+        entry = {
+            "id": "api-guidelines",
+            "type": "local",
+            "path": "api-guidelines",
+            "targets": ["APIGuidelines"],
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_git_valid_with_targets(self):
+        entry = {
+            "id": "swift-testing",
+            "type": "git",
+            "repo": "https://github.com/swiftlang/swift-testing.git",
+            "ref": "main",
+            "targets": ["Testing"],
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_git_valid_with_catalog(self):
+        entry = {
+            "id": "swift-book",
+            "type": "git",
+            "repo": "https://github.com/swiftlang/swift-book.git",
+            "ref": "main",
+            "docc_catalog": "TSPL.docc",
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_git_missing_ref_rejected(self):
+        entry = {
+            "id": "swift-book",
+            "type": "git",
+            "repo": "https://github.com/swiftlang/swift-book.git",
+            "docc_catalog": "TSPL.docc",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("ref", output)
+
+
+def _make_tarball(tmp_path, archive_name, wrap_top_level=True):
+    """Build a tar.gz containing a minimal .doccarchive directory.
+
+    When wrap_top_level is True, the tarball's root entry is the .doccarchive
+    directory itself; when False, its contents are at the tarball root.
+    Returns the path to the tarball.
+    """
+    archive_dir = tmp_path / archive_name
+    archive_dir.mkdir()
+    (archive_dir / "metadata.json").write_text('{"bundleDisplayName":"Test"}')
+    (archive_dir / "index").mkdir()
+    (archive_dir / "index" / "index.json").write_text("{}")
+
+    tarball = tmp_path / f"{archive_name}.tar.gz"
+    with tarfile.open(str(tarball), "w:gz") as tar:
+        if wrap_top_level:
+            tar.add(str(archive_dir), arcname=archive_name)
+        else:
+            for entry in archive_dir.rglob("*"):
+                rel = entry.relative_to(archive_dir)
+                tar.add(str(entry), arcname=str(rel))
+    return tarball
+
+
+class FetchArchive(unittest.TestCase):
+    def test_successful_fetch_with_wrapped_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(tmp_path, "Swift.doccarchive")
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            source = {
+                "id": "stdlib",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            result = build_docs.fetch_archive(source, workspace)
+            self.assertTrue(result.is_dir())
+            self.assertEqual(result.name, "Swift.doccarchive")
+            self.assertTrue((result / "metadata.json").is_file())
+
+    def test_successful_fetch_with_unwrapped_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(
+                tmp_path, "Swift.doccarchive", wrap_top_level=False
+            )
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            source = {
+                "id": "stdlib",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            with self.assertRaises(build_docs.ArchiveFetchError):
+                build_docs.fetch_archive(source, workspace)
+
+    def test_download_failure_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            workspace.mkdir()
+            source = {
+                "id": "stdlib",
+                "url": "file:///no/such/path/archive.tar.gz",
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            with self.assertRaises(build_docs.ArchiveFetchError):
+                build_docs.fetch_archive(source, workspace)
+
+    def test_missing_docc_archive_name_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(tmp_path, "Other.doccarchive")
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            source = {
+                "id": "stdlib",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            with self.assertRaises(build_docs.ArchiveFetchError):
+                build_docs.fetch_archive(source, workspace)
+
+    def test_rerun_wipes_previous_download(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(tmp_path, "Swift.doccarchive")
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            source = {
+                "id": "stdlib",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            first = build_docs.fetch_archive(source, workspace)
+            # Seed a stale file so we can verify re-entry wiped the directory.
+            stale = first.parent.parent / "stale.txt"
+            stale.write_text("stale")
+            second = build_docs.fetch_archive(source, workspace)
+            self.assertTrue(second.is_dir())
+            self.assertFalse(stale.exists())
+
+
+class BuildSourceArchiveBranch(unittest.TestCase):
+    def test_archive_source_copies_to_temp_and_returns_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(tmp_path, "Swift.doccarchive")
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            temp_archive_dir = workspace / "_archives"
+            temp_archive_dir.mkdir()
+            source = {
+                "id": "stdlib",
+                "type": "archive",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+                "version_label": "main",
+            }
+            archives, manifest_entry = build_docs.build_source(
+                source,
+                root_dir=tmp_path,
+                workspace=workspace,
+                common_dir=tmp_path,
+                temp_archive_dir=temp_archive_dir,
+                docc_cmd=[],
+                env={},
+            )
+            self.assertEqual(len(archives), 1)
+            self.assertEqual(archives[0].name, "stdlib.doccarchive")
+            self.assertTrue(archives[0].is_dir())
+            self.assertTrue((archives[0] / "metadata.json").is_file())
+            self.assertEqual(manifest_entry["id"], "stdlib")
+            self.assertEqual(manifest_entry["type"], "archive")
+            self.assertEqual(manifest_entry["ref"], "main")
+            self.assertEqual(manifest_entry["commit"], "")
+            self.assertEqual(manifest_entry["url"], tarball.as_uri())
+
+    def test_archive_source_without_version_label(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(tmp_path, "Swift.doccarchive")
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            temp_archive_dir = workspace / "_archives"
+            temp_archive_dir.mkdir()
+            source = {
+                "id": "stdlib",
+                "type": "archive",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            _, manifest_entry = build_docs.build_source(
+                source,
+                root_dir=tmp_path,
+                workspace=workspace,
+                common_dir=tmp_path,
+                temp_archive_dir=temp_archive_dir,
+                docc_cmd=[],
+                env={},
+            )
+            self.assertEqual(manifest_entry["ref"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1125,5 +1125,90 @@ class FinalizeCombinedArchive(unittest.TestCase):
         self.assertEqual(failed, [])
 
 
+class CleanPackageBuildDirs(unittest.TestCase):
+    def test_removes_build_dir_for_local_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = root / "server-guides"
+            pkg.mkdir()
+            (pkg / "Package.swift").write_text("// swift-tools-version:6.0\n")
+            (pkg / ".build").mkdir()
+            (pkg / ".build" / "stale.txt").write_text("x")
+
+            sources = [
+                {"id": "server-guides", "type": "local", "path": "server-guides"}
+            ]
+            removed = build_docs.clean_package_build_dirs(root, sources)
+
+            self.assertFalse((pkg / ".build").exists())
+            self.assertEqual(len(removed), 1)
+            self.assertEqual(removed[0], (pkg / ".build").resolve())
+
+    def test_removes_build_dirs_for_repo_root_packages_not_in_sources(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name in ["api-guidelines", "language-guides"]:
+                pkg = root / name
+                pkg.mkdir()
+                (pkg / "Package.swift").write_text("// swift-tools-version:6.0\n")
+                (pkg / ".build").mkdir()
+            removed = build_docs.clean_package_build_dirs(root, sources=[])
+            self.assertEqual(len(removed), 2)
+            for name in ["api-guidelines", "language-guides"]:
+                self.assertFalse((root / name / ".build").exists())
+
+    def test_dedupes_when_local_source_is_also_repo_root_package(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = root / "server-guides"
+            pkg.mkdir()
+            (pkg / "Package.swift").write_text("// swift-tools-version:6.0\n")
+            (pkg / ".build").mkdir()
+
+            sources = [
+                {"id": "server-guides", "type": "local", "path": "server-guides"}
+            ]
+            removed = build_docs.clean_package_build_dirs(root, sources)
+            self.assertEqual(len(removed), 1)
+
+    def test_skips_directories_without_build(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = root / "api-guidelines"
+            pkg.mkdir()
+            (pkg / "Package.swift").write_text("// swift-tools-version:6.0\n")
+            removed = build_docs.clean_package_build_dirs(root, sources=[])
+            self.assertEqual(removed, [])
+
+    def test_ignores_non_package_subdirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            common = root / "common"
+            common.mkdir()
+            (common / ".build").mkdir()  # no Package.swift — must not be removed
+            removed = build_docs.clean_package_build_dirs(root, sources=[])
+            self.assertEqual(removed, [])
+            self.assertTrue((common / ".build").exists())
+
+    def test_ignores_non_local_sources(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sources = [
+                {
+                    "id": "x",
+                    "type": "git",
+                    "repo": "https://example.com/x.git",
+                    "ref": "main",
+                },
+                {
+                    "id": "y",
+                    "type": "archive",
+                    "url": "https://example.com/y.tar.gz",
+                },
+            ]
+            removed = build_docs.clean_package_build_dirs(root, sources)
+            self.assertEqual(removed, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -6,15 +6,19 @@ Run from the scripts/ directory (or repo root) with:
 
 import contextlib
 import io
+import json
+import subprocess
 import sys
 import tarfile
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import build_docs  # noqa: E402
+import strip_availability  # noqa: E402
 
 
 def _validate(config):
@@ -89,9 +93,9 @@ class ValidateArchiveType(unittest.TestCase):
         entry = {
             "id": "stdlib",
             "type": "archive",
-            "url": "https://example.com/Swift.doccarchive.zip",
+            "url": "https://example.com/Swift.doccarchive.7z",
             "docc_archive_name": "Swift.doccarchive",
-            "format": "zip",
+            "format": "7z",
         }
         output = _validate(_wrap(entry))
         self.assertIsNotNone(output)
@@ -133,6 +137,66 @@ class ValidateArchiveType(unittest.TestCase):
         output = _validate(_wrap(entry))
         self.assertIsNotNone(output)
         self.assertIn("unknown type", output)
+
+    def test_strip_availability_true_is_valid(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.zip",
+            "docc_archive_name": "Swift.doccarchive",
+            "format": "zip",
+            "strip_availability": True,
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_strip_availability_false_is_valid(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.tar.gz",
+            "docc_archive_name": "Swift.doccarchive",
+            "strip_availability": False,
+        }
+        self.assertIsNone(_validate(_wrap(entry)))
+
+    def test_strip_availability_non_bool_rejected(self):
+        entry = {
+            "id": "stdlib",
+            "type": "archive",
+            "url": "https://example.com/Swift.doccarchive.tar.gz",
+            "docc_archive_name": "Swift.doccarchive",
+            "strip_availability": "yes",
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("strip_availability", output)
+
+
+class ValidateStripAvailabilityOnNonArchive(unittest.TestCase):
+    def test_rejected_on_git_source(self):
+        entry = {
+            "id": "swift-book",
+            "type": "git",
+            "repo": "https://github.com/swiftlang/swift-book.git",
+            "ref": "main",
+            "docc_catalog": "TSPL.docc",
+            "strip_availability": True,
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("strip_availability", output)
+
+    def test_rejected_on_local_source(self):
+        entry = {
+            "id": "api-guidelines",
+            "type": "local",
+            "path": "api-guidelines",
+            "targets": ["APIGuidelines"],
+            "strip_availability": True,
+        }
+        output = _validate(_wrap(entry))
+        self.assertIsNotNone(output)
+        self.assertIn("strip_availability", output)
 
 
 class ValidateExistingTypesStillWork(unittest.TestCase):
@@ -179,11 +243,13 @@ class ValidateExistingTypesStillWork(unittest.TestCase):
         self.assertIn("ref", output)
 
 
-def _make_tarball(tmp_path, archive_name, wrap_top_level=True):
+def _make_tarball(tmp_path, archive_name, wrap_top_level=True, with_platforms=False):
     """Build a tar.gz containing a minimal .doccarchive directory.
 
     When wrap_top_level is True, the tarball's root entry is the .doccarchive
     directory itself; when False, its contents are at the tarball root.
+    When with_platforms is True, seed a data/ directory with a JSON file that
+    contains a metadata.platforms key (so strip_archive() has something to find).
     Returns the path to the tarball.
     """
     archive_dir = tmp_path / archive_name
@@ -191,6 +257,21 @@ def _make_tarball(tmp_path, archive_name, wrap_top_level=True):
     (archive_dir / "metadata.json").write_text('{"bundleDisplayName":"Test"}')
     (archive_dir / "index").mkdir()
     (archive_dir / "index" / "index.json").write_text("{}")
+
+    if with_platforms:
+        data_dir = archive_dir / "data" / "documentation"
+        data_dir.mkdir(parents=True)
+        (data_dir / "x.json").write_text(
+            json.dumps(
+                {
+                    "metadata": {
+                        "title": "X",
+                        "platforms": [{"name": "iOS"}],
+                    },
+                    "kind": "symbol",
+                }
+            )
+        )
 
     tarball = tmp_path / f"{archive_name}.tar.gz"
     with tarfile.open(str(tarball), "w:gz") as tar:
@@ -341,6 +422,340 @@ class BuildSourceArchiveBranch(unittest.TestCase):
                 env={},
             )
             self.assertEqual(manifest_entry["ref"], "")
+
+    def test_strip_availability_removes_platforms_from_copied_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(
+                tmp_path, "Swift.doccarchive", with_platforms=True
+            )
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            temp_archive_dir = workspace / "_archives"
+            temp_archive_dir.mkdir()
+            source = {
+                "id": "stdlib",
+                "type": "archive",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+                "strip_availability": True,
+            }
+            archives, _ = build_docs.build_source(
+                source,
+                root_dir=tmp_path,
+                workspace=workspace,
+                common_dir=tmp_path,
+                temp_archive_dir=temp_archive_dir,
+                docc_cmd=[],
+                env={},
+            )
+            data_file = archives[0] / "data" / "documentation" / "x.json"
+            payload = json.loads(data_file.read_text())
+            self.assertNotIn("platforms", payload["metadata"])
+            self.assertEqual(payload["metadata"]["title"], "X")
+
+    def test_strip_availability_absent_leaves_platforms(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball = _make_tarball(
+                tmp_path, "Swift.doccarchive", with_platforms=True
+            )
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            temp_archive_dir = workspace / "_archives"
+            temp_archive_dir.mkdir()
+            source = {
+                "id": "stdlib",
+                "type": "archive",
+                "url": tarball.as_uri(),
+                "docc_archive_name": "Swift.doccarchive",
+            }
+            archives, _ = build_docs.build_source(
+                source,
+                root_dir=tmp_path,
+                workspace=workspace,
+                common_dir=tmp_path,
+                temp_archive_dir=temp_archive_dir,
+                docc_cmd=[],
+                env={},
+            )
+            data_file = archives[0] / "data" / "documentation" / "x.json"
+            payload = json.loads(data_file.read_text())
+            self.assertIn("platforms", payload["metadata"])
+
+
+def _make_archive_with_platforms(root, archive_name="Swift.doccarchive"):
+    """Build a minimal .doccarchive tree on disk with platforms data sprinkled in.
+
+    Returns the archive path. The tree contains data/ JSON files with both
+    metadata.platforms and primaryContentSections[*].declarations[*].platforms,
+    so strip_archive() should remove them and not touch unrelated keys.
+    """
+    archive = root / archive_name
+    data_dir = archive / "data" / "documentation"
+    data_dir.mkdir(parents=True)
+
+    symbol = {
+        "metadata": {
+            "title": "FooSymbol",
+            "platforms": [{"name": "iOS", "introducedAt": "13.0"}],
+        },
+        "primaryContentSections": [
+            {
+                "kind": "declarations",
+                "declarations": [
+                    {
+                        "tokens": [{"text": "func foo()"}],
+                        "platforms": ["macOS"],
+                    }
+                ],
+            }
+        ],
+        "kind": "symbol",
+    }
+    (data_dir / "foosymbol.json").write_text(json.dumps(symbol))
+
+    article = {
+        "metadata": {"title": "Article"},
+        "kind": "article",
+    }
+    (data_dir / "article.json").write_text(json.dumps(article))
+
+    return archive
+
+
+class StripArchive(unittest.TestCase):
+    def test_removes_platforms_keys_and_returns_counts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_platforms(Path(tmp))
+            scanned, modified, removed = strip_availability.strip_archive(archive)
+
+            symbol = json.loads(
+                (archive / "data" / "documentation" / "foosymbol.json").read_text()
+            )
+            self.assertNotIn("platforms", symbol["metadata"])
+            self.assertNotIn(
+                "platforms", symbol["primaryContentSections"][0]["declarations"][0]
+            )
+            # Unrelated keys preserved.
+            self.assertEqual(symbol["metadata"]["title"], "FooSymbol")
+            self.assertEqual(
+                symbol["primaryContentSections"][0]["declarations"][0]["tokens"],
+                [{"text": "func foo()"}],
+            )
+
+            self.assertEqual(scanned, 2)
+            self.assertEqual(modified, 1)
+            self.assertEqual(removed, 2)
+
+    def test_archive_without_platforms_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "Swift.doccarchive"
+            data_dir = archive / "data"
+            data_dir.mkdir(parents=True)
+            payload = {"metadata": {"title": "X"}, "kind": "article"}
+            (data_dir / "x.json").write_text(json.dumps(payload))
+
+            scanned, modified, removed = strip_availability.strip_archive(archive)
+            self.assertEqual(scanned, 1)
+            self.assertEqual(modified, 0)
+            self.assertEqual(removed, 0)
+            self.assertEqual(
+                json.loads((data_dir / "x.json").read_text()), payload
+            )
+
+    def test_missing_data_dir_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            not_an_archive = Path(tmp) / "NotAnArchive"
+            not_an_archive.mkdir()
+            with self.assertRaises(ValueError):
+                strip_availability.strip_archive(not_an_archive)
+
+
+class TransformStaticHosting(unittest.TestCase):
+    def test_invokes_docc_with_correct_args_and_replaces_in_place(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "main.doccarchive"
+            archive.mkdir()
+            (archive / "index.html").write_text("ORIGINAL")
+
+            captured = {}
+
+            def fake_run(cmd, check, **kw):
+                captured["cmd"] = cmd
+                # Simulate docc producing the transformed archive at --output-path.
+                idx = cmd.index("--output-path") + 1
+                out_path = Path(cmd[idx])
+                out_path.mkdir(parents=True, exist_ok=True)
+                (out_path / "index.html").write_text("TRANSFORMED")
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                build_docs.transform_static_hosting(archive, "main", ["docc"])
+
+            self.assertEqual(
+                captured["cmd"][:3],
+                ["docc", "process-archive", "transform-for-static-hosting"],
+            )
+            self.assertIn("--hosting-base-path", captured["cmd"])
+            hbp_idx = captured["cmd"].index("--hosting-base-path") + 1
+            self.assertEqual(captured["cmd"][hbp_idx], "main")
+            # Archive replaced in place.
+            self.assertTrue(archive.is_dir())
+            self.assertEqual((archive / "index.html").read_text(), "TRANSFORMED")
+
+    def test_failure_leaves_original_archive_untouched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "main.doccarchive"
+            archive.mkdir()
+            (archive / "index.html").write_text("ORIGINAL")
+
+            def fake_run(cmd, check, **kw):
+                raise subprocess.CalledProcessError(1, cmd)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    build_docs.transform_static_hosting(archive, "main", ["docc"])
+
+            self.assertTrue(archive.is_dir())
+            self.assertEqual((archive / "index.html").read_text(), "ORIGINAL")
+
+    def test_raises_when_docc_cmd_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "main.doccarchive"
+            archive.mkdir()
+            with self.assertRaises(RuntimeError):
+                build_docs.transform_static_hosting(archive, "main", [])
+
+
+class FindSwiftly(unittest.TestCase):
+    def test_returns_command_when_on_path(self):
+        with mock.patch.object(build_docs.shutil, "which", return_value="/usr/local/bin/swiftly"):
+            self.assertEqual(build_docs.find_swiftly(), ["swiftly"])
+
+    def test_returns_empty_when_absent(self):
+        with mock.patch.object(build_docs.shutil, "which", return_value=None):
+            self.assertEqual(build_docs.find_swiftly(), [])
+
+
+class FindSwiftCommand(unittest.TestCase):
+    def test_prefers_swiftly_when_available(self):
+        def fake_which(name):
+            return f"/fake/{name}" if name == "swiftly" else None
+        with mock.patch.object(build_docs.shutil, "which", side_effect=fake_which):
+            self.assertEqual(build_docs.find_swift_command(), ["swiftly", "run", "swift"])
+
+    def test_falls_back_to_direct_swift(self):
+        def fake_which(name):
+            return "/usr/bin/swift" if name == "swift" else None
+        with mock.patch.object(build_docs.shutil, "which", side_effect=fake_which):
+            self.assertEqual(build_docs.find_swift_command(), ["swift"])
+
+    def test_returns_empty_when_neither_present(self):
+        with mock.patch.object(build_docs.shutil, "which", return_value=None):
+            self.assertEqual(build_docs.find_swift_command(), [])
+
+
+class FindDoccCommandPrefersSwiftly(unittest.TestCase):
+    def test_prefers_swiftly_when_available(self):
+        def fake_which(name):
+            return f"/fake/{name}" if name == "swiftly" else None
+        with mock.patch.object(build_docs.shutil, "which", side_effect=fake_which):
+            self.assertEqual(
+                build_docs.find_docc_command(),
+                ["swiftly", "run", "docc"],
+            )
+
+
+class EnsureToolchainInstalled(unittest.TestCase):
+    def test_no_swift_version_file_skips_install(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = Path(tmp)
+            calls = []
+
+            def fake_run(cmd, check, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                build_docs.ensure_toolchain_installed(source_dir, ["swiftly"])
+
+            self.assertEqual(calls, [])
+
+    def test_swift_version_file_triggers_install_in_source_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = Path(tmp)
+            (source_dir / ".swift-version").write_text("6.0.1\n")
+
+            captured = {}
+
+            def fake_run(cmd, check, **kw):
+                captured["cmd"] = cmd
+                captured["cwd"] = kw.get("cwd")
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                build_docs.ensure_toolchain_installed(source_dir, ["swiftly"])
+
+            self.assertEqual(captured["cmd"][:2], ["swiftly", "install"])
+            self.assertIn("--assume-yes", captured["cmd"])
+            self.assertEqual(captured["cwd"], str(source_dir))
+
+    def test_no_swiftly_skips_even_with_version_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = Path(tmp)
+            (source_dir / ".swift-version").write_text("6.0.1\n")
+            calls = []
+
+            def fake_run(cmd, check, **kw):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                build_docs.ensure_toolchain_installed(source_dir, [])
+
+            self.assertEqual(calls, [])
+
+
+class ReadSwiftToolsVersion(unittest.TestCase):
+    def _write_package(self, dir_, first_line):
+        pkg = Path(dir_) / "Package.swift"
+        pkg.write_text(first_line + "\nimport PackageDescription\n")
+        return pkg
+
+    def test_parses_simple_major_minor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "// swift-tools-version: 6.3")
+            self.assertEqual(build_docs.read_swift_tools_version(Path(tmp)), "6.3")
+
+    def test_parses_no_space_after_colon(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "// swift-tools-version:5.10")
+            self.assertEqual(build_docs.read_swift_tools_version(Path(tmp)), "5.10")
+
+    def test_strips_patch_to_major_minor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "// swift-tools-version:5.5.2")
+            self.assertEqual(build_docs.read_swift_tools_version(Path(tmp)), "5.5")
+
+    def test_handles_extended_form_with_semicolon(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "// swift-tools-version:5.5;something")
+            self.assertEqual(build_docs.read_swift_tools_version(Path(tmp)), "5.5")
+
+    def test_returns_none_when_no_package_swift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(build_docs.read_swift_tools_version(Path(tmp)))
+
+    def test_returns_none_when_first_line_unrelated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_package(tmp, "// some other comment")
+            self.assertIsNone(build_docs.read_swift_tools_version(Path(tmp)))
+
+    def test_returns_none_when_empty_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "Package.swift").write_text("")
+            self.assertIsNone(build_docs.read_swift_tools_version(Path(tmp)))
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 """Tests for build_docs.py.
 
 Run from the scripts/ directory (or repo root) with:


### PR DESCRIPTION
## Summary

build_script works from Swift Packages in git and local directories today - building the content, then merging it together. This extends that concept to accepting an externally built DocC archive in some form and integrating that into the combined build.

- adds structure and support for sources.json to specify a pre-built DocC archive to use in the combined build (for Swift standard library)
- adds better support for loading and using swiftly correctly IF swiftly is installed locally, and if the the repository being grabbed is pinned to a specific version (swiftpm, swift-testing)
- applies the version as the hosting-base-path for the whole combined collection at the tail end of this build process, prepping it for an immediate cache or deployment to a static server with that prefix URL. Default in this set to `main`, from sources.json
- strips availability data from the Swift standard library - long term not want we want, but provides a generic view of the standard library that's not being inclusive to Apple platforms and implying that others aren't supported. Longer term, want to strip this out and handle the scenario where we build the standard library from multiple platforms and combine the symbols together for broader availability markings in that DocC archive.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
