### PR TITLE
Update URL for Swift standard library documentation

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -12,7 +12,7 @@
     {
       "id": "swift-stdlib",
       "type": "archive",
-      "url": "https://ci.swift.org/job/build-stdlib-docs/36/artifact/*zip*/archive.zip",
+      "url": "https://download.swift.org/docs/main/swift_docc.zip",
       "format": "zip",
       "docc_archive_name": "Swift.doccarchive",
       "strip_availability": true


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->


## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
