### PR TITLE
Set synthesized landing page name and list topics style for combined archive

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,12 +19,14 @@ open http://localhost:8000/main/documentation/
 
 `navigation.json` controls the left-hand navigator of the **combined** archive
 (`docc merge` output): it groups modules under labelled sections, hides
-internal modules, and orders them. Each entry names a `source` (a `sources.json`
-id) and the module `path` it applies to. Every module in the merged index must
-be either placed in a group or listed under `hidden` — `build_docs.py` validates
-and applies this automatically (the `navigator-curation` build step), and fails
-the build on any mismatch or uncovered module. See `../hacking-index-json.md`
-for the underlying mechanics.
+internal modules, and orders them. Hidden modules are also pruned from the
+synthesized landing page body (`data/documentation.json`), so they disappear
+from the main page's module list as well as the sidebar. Each entry names a
+`source` (a `sources.json` id) and the module `path` it applies to. Every module
+in the merged index must be either placed in a group or listed under `hidden` —
+`build_docs.py` validates and applies this automatically (the
+`navigator-curation` build step), and fails the build on any mismatch or
+uncovered module. See `../hacking-index-json.md` for the underlying mechanics.
 
 ### Checking the manifest while editing
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+## Local validation
+
+To build the combined documentation and view the result locally:
+
+- from the docs repository root:
+```bash
+set -e
+./scripts/build_docs.py
+python3 -m http.server 8000 --directory .build-output
+```
+
+Then in another terminal:
+
+```bash
+open http://localhost:8000/main/documentation/
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,3 +14,36 @@ Then in another terminal:
 ```bash
 open http://localhost:8000/main/documentation/
 ```
+
+## Navigation manifest (combined sidebar curation)
+
+`navigation.json` controls the left-hand navigator of the **combined** archive
+(`docc merge` output): it groups modules under labelled sections, hides
+internal modules, and orders them. Each entry names a `source` (a `sources.json`
+id) and the module `path` it applies to. Every module in the merged index must
+be either placed in a group or listed under `hidden` — `build_docs.py` validates
+and applies this automatically (the `navigator-curation` build step), and fails
+the build on any mismatch or uncovered module. See `../hacking-index-json.md`
+for the underlying mechanics.
+
+### Checking the manifest while editing
+
+Run the standalone checker — it does **not** modify any build output:
+
+```bash
+# From the repo root. Validates navigation.json against sources.json
+# (no unknown sources, every source represented) and, if a combined archive
+# exists at .build-output/<version>, dry-runs curation and previews the sidebar.
+python3 scripts/validate_navigation.py
+```
+
+It exits non-zero when the manifest is invalid or a built archive contains a
+module the manifest neither groups nor hides — so it doubles as a coverage
+check. Point it at a specific archive (e.g. one you just built elsewhere) with:
+
+```bash
+python3 scripts/validate_navigation.py --archive path/to/combined.doccarchive
+```
+
+`--navigation` and `--sources` can override the input files for experimentation.
+

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -30,6 +30,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from strip_availability import strip_archive
+from curate_navigator import curate_navigator, validate_navigation, NavigationError
 
 
 class ArchiveFetchError(Exception):
@@ -876,13 +877,14 @@ def inject_custom_templates_into_stubs(archive_path, common_dir):
     return patched
 
 
-def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prior_failed, common_dir=None):
+def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prior_failed, common_dir=None, navigation=None):
     """Merge per-source archives and apply the static-hosting transform.
 
     Returns (succeeded_steps, failed_steps): names that should be added to
     the build summary's success and failure lists, respectively. Bails early
-    on missing prerequisites; isolates the merge step from the transform step
-    so a transform failure still records the merge as succeeded.
+    on missing prerequisites; isolates the merge step from the curation and
+    transform steps so a later failure still records the earlier steps as
+    succeeded.
     """
     print()
     print("=" * 40)
@@ -917,18 +919,32 @@ def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prio
         print("Error: docc merge failed")
         return [], ["combined-merge"]
 
+    if navigation is not None:
+        try:
+            curate_navigator(combined_output, navigation)
+            print("Curated combined navigator per navigation.json.")
+        except (NavigationError, OSError, json.JSONDecodeError) as e:
+            print(f"Error: navigator curation failed: {e}")
+            return ["combined-merge"], ["navigator-curation"]
+
     try:
         transform_static_hosting(combined_output, version, docc_cmd)
     except subprocess.CalledProcessError:
         print("Error: docc process-archive transform-for-static-hosting failed")
-        return ["combined-merge"], ["static-hosting-transform"]
+        curated = ["combined-merge"]
+        if navigation is not None:
+            curated.append("navigator-curation")
+        return curated, ["static-hosting-transform"]
 
     # Workaround for swiftlang/swift-docc#1532 — drop this when fixed.
     if common_dir is not None:
         patched = inject_custom_templates_into_stubs(combined_output, common_dir)
         print(f"Patched custom-header/footer into {patched} per-route stub(s).")
 
-    return ["combined-merge", "static-hosting-transform"], []
+    succeeded = ["combined-merge", "static-hosting-transform"]
+    if navigation is not None:
+        succeeded.insert(1, "navigator-curation")
+    return succeeded, []
 
 
 def assemble_in_source_order(results_by_index, num_sources):
@@ -1016,6 +1032,26 @@ def main():
         sys.exit(1)
     print(f"Validated {len(config['sources'])} source entries.")
 
+    # Load and validate the navigation manifest (drives combined-archive
+    # sidebar curation). Validated up front so a mismatch fails fast.
+    navigation_file = script_dir / "navigation.json"
+    navigation = None
+    if navigation_file.is_file():
+        try:
+            navigation = json.loads(navigation_file.read_text())
+        except json.JSONDecodeError as e:
+            print(f"Error: navigation.json is not valid JSON: {e}")
+            sys.exit(1)
+        nav_errors = validate_navigation(navigation, config)
+        if nav_errors:
+            for e in nav_errors:
+                print(f"Validation error: {e}")
+            print("\nFix the errors in navigation.json before continuing.")
+            sys.exit(1)
+        print("Validated navigation.json against sources.json.")
+    else:
+        print("No navigation.json found — combined navigator will not be curated.")
+
     version = config["version"]
     sources = config["sources"]
 
@@ -1098,7 +1134,7 @@ def main():
     if all_archives and not args.only:
         s_steps, f_steps = _finalize_combined_archive(
             all_archives, output_dir, version, tools.docc, failed,
-            common_dir=common_dir,
+            common_dir=common_dir, navigation=navigation,
         )
         succeeded.extend(s_steps)
         failed.extend(f_steps)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -793,6 +793,7 @@ def merge_archives(archives, output_path, docc_cmd, landing_page_name):
     cmd = docc_cmd + ["merge"] + [str(a) for a in archives] + [
         "--output-path", str(output_path),
         "--synthesized-landing-page-name", landing_page_name,
+        "--synthesized-landing-page-kind", "Project",
         "--synthesized-landing-page-topics-style", "list",
     ]
     subprocess.run(cmd, check=True)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -835,7 +835,48 @@ def transform_static_hosting(archive_path, hosting_base_path, docc_cmd):
     print(f"Transformed archive: {archive_path}")
 
 
-def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prior_failed):
+def inject_custom_templates_into_stubs(archive_path, common_dir):
+    """Inject custom-header/custom-footer templates into per-route index.html stubs.
+
+    Workaround for swiftlang/swift-docc#1532. `docc process-archive
+    transform-for-static-hosting` regenerates a stripped index.html for every
+    route under the archive, and those stubs do not include the
+    `<template id="custom-header">` / `<template id="custom-footer">` blocks
+    that `docc convert`/`docc merge` baked into the archive root. Without
+    this fix, only the archive-root index.html displays the custom header and
+    footer; every other route is served by a stub that lacks them.
+
+    Walks every index.html under archive_path except the root, skips any file
+    that already contains custom-header (idempotent — and self-disabling once
+    DocC fixes the upstream bug), and inserts both template blocks immediately
+    after `<body data-color-scheme="auto">` to mirror the placement
+    docc convert produces in the root. Returns the number of stubs patched.
+    """
+    header = (common_dir / "header.html").read_text()
+    footer = (common_dir / "footer.html").read_text()
+    anchor = '<body data-color-scheme="auto">'
+    # Mirror docc convert ordering: footer template first, then header.
+    injection = (
+        anchor
+        + f'<template id="custom-footer">{footer}</template>'
+        + f'<template id="custom-header">{header}</template>'
+    )
+
+    archive_path = Path(archive_path)
+    root_index = (archive_path / "index.html").resolve()
+    patched = 0
+    for index_path in archive_path.rglob("index.html"):
+        if index_path.resolve() == root_index:
+            continue
+        text = index_path.read_text()
+        if "custom-header" in text or anchor not in text:
+            continue
+        index_path.write_text(text.replace(anchor, injection, 1))
+        patched += 1
+    return patched
+
+
+def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prior_failed, common_dir=None):
     """Merge per-source archives and apply the static-hosting transform.
 
     Returns (succeeded_steps, failed_steps): names that should be added to
@@ -881,6 +922,11 @@ def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prio
     except subprocess.CalledProcessError:
         print("Error: docc process-archive transform-for-static-hosting failed")
         return ["combined-merge"], ["static-hosting-transform"]
+
+    # Workaround for swiftlang/swift-docc#1532 — drop this when fixed.
+    if common_dir is not None:
+        patched = inject_custom_templates_into_stubs(combined_output, common_dir)
+        print(f"Patched custom-header/footer into {patched} per-route stub(s).")
 
     return ["combined-merge", "static-hosting-transform"], []
 
@@ -1051,7 +1097,8 @@ def main():
     # Merge all archives — only when building everything (not --only)
     if all_archives and not args.only:
         s_steps, f_steps = _finalize_combined_archive(
-            all_archives, output_dir, version, tools.docc, failed
+            all_archives, output_dir, version, tools.docc, failed,
+            common_dir=common_dir,
         )
         succeeded.extend(s_steps)
         failed.extend(f_steps)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -884,6 +884,31 @@ def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prio
     return ["combined-merge", "static-hosting-transform"], []
 
 
+def assemble_in_source_order(results_by_index, num_sources):
+    """Flatten per-source build results into strict sources.json order.
+
+    `results_by_index` maps a source's position in sources.json to its
+    (archives, manifest_entry) result. Build order may differ from source
+    order (archive-type sources are built first for fail-fast), so this
+    reassembles by ascending index to guarantee the merge — and the manifest
+    — follow sources.json exactly. Indices with no result (skipped or failed
+    sources) are omitted. A source's archives stay grouped and in the order
+    build_source returned them (e.g. multi-target packages).
+
+    Returns (all_archives, manifest_entries).
+    """
+    all_archives = []
+    manifest_entries = []
+    for i in range(num_sources):
+        result = results_by_index.get(i)
+        if result is None:
+            continue
+        archives, entry = result
+        all_archives.extend(archives)
+        manifest_entries.append(entry)
+    return all_archives, manifest_entries
+
+
 def write_manifest(output_dir, version, entries):
     """Write build-manifest.json to the output directory."""
     manifest = {
@@ -969,15 +994,14 @@ def main():
     # Track results
     succeeded = []
     failed = []
-    all_archives = []
-    manifest_entries = []
+    results_by_index = {}
 
-    # Preflight: fetch archive-type sources first so network or extraction
-    # failures abort the run before any slow git clones or swift builds.
-    archive_sources = [s for s in sources if s["type"] == "archive"]
-    other_sources = [s for s in sources if s["type"] != "archive"]
-
-    def attempt_build(source, fatal=(), recoverable=()):
+    # Build archive-type sources first so network or extraction failures abort
+    # the run before any slow git clones or swift builds. Build order is
+    # decoupled from merge order: each result is keyed by the source's position
+    # in sources.json, then reassembled in that order below so the merge — and
+    # the manifest — strictly follow sources.json regardless of build order.
+    def attempt_build(index, source, fatal=(), recoverable=()):
         """Run build_source for one entry, sorting exceptions by severity.
 
         `fatal` exceptions print and sys.exit(1). `recoverable` exceptions are
@@ -1001,13 +1025,18 @@ def main():
             failed.append(sid)
             return
         succeeded.append(sid)
-        all_archives.extend(archives)
-        manifest_entries.append(entry)
+        results_by_index[index] = (archives, entry)
 
-    for source in archive_sources:
-        attempt_build(source, fatal=(ArchiveFetchError,))
-    for source in other_sources:
-        attempt_build(source, recoverable=(Exception,))
+    for i, source in enumerate(sources):
+        if source["type"] == "archive":
+            attempt_build(i, source, fatal=(ArchiveFetchError,))
+    for i, source in enumerate(sources):
+        if source["type"] != "archive":
+            attempt_build(i, source, recoverable=(Exception,))
+
+    all_archives, manifest_entries = assemble_in_source_order(
+        results_by_index, len(sources)
+    )
 
     # When --only is used, copy the single source's archive to output directly
     if args.only and all_archives:

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -781,7 +781,7 @@ def build_source(source, root_dir, workspace, common_dir, temp_archive_dir, docc
     return archives, manifest_entry
 
 
-def merge_archives(archives, output_path, docc_cmd):
+def merge_archives(archives, output_path, docc_cmd, landing_page_name):
     """Merge multiple .doccarchive directories into one using docc merge."""
     if output_path.exists():
         shutil.rmtree(str(output_path))
@@ -792,6 +792,8 @@ def merge_archives(archives, output_path, docc_cmd):
 
     cmd = docc_cmd + ["merge"] + [str(a) for a in archives] + [
         "--output-path", str(output_path),
+        "--synthesized-landing-page-name", landing_page_name,
+        "--synthesized-landing-page-topics-style", "list",
     ]
     subprocess.run(cmd, check=True)
     print(f"Combined archive: {output_path}")
@@ -865,7 +867,10 @@ def _finalize_combined_archive(all_archives, output_dir, version, docc_cmd, prio
 
     combined_output = output_dir / f"{version}"
     try:
-        merge_archives(all_archives, combined_output, docc_cmd)
+        merge_archives(
+            all_archives, combined_output, docc_cmd,
+            landing_page_name=f"Swift - {version}",
+        )
     except subprocess.CalledProcessError:
         print("Error: docc merge failed")
         return [], ["combined-merge"]

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+"""Curate the combined DocC archive's navigator sidebar.
+
+After ``docc merge`` produces the combined archive, its left-hand navigator is
+driven by ``<archive>/index/index.json`` →
+``interfaceLanguages.<lang>[0].children[]`` — a flat list of one node per merged
+module. This module rewrites that list per ``navigation.json``: hiding modules,
+grouping the rest under ``groupMarker`` labels, and ordering them explicitly.
+
+See ``hacking-index-json.md`` for the verified mechanics.
+"""
+
+import json
+import os
+from pathlib import Path
+
+
+class NavigationError(Exception):
+    """Raised when curation cannot be applied (dangling/unlisted modules, etc.)."""
+
+
+def validate_navigation(navigation, sources_config):
+    """Validate navigation.json against itself and sources.json (offline).
+
+    Returns a list of human-readable error strings; empty means valid.
+    """
+    raise NotImplementedError
+
+
+def curate_navigator(archive_path, navigation):
+    """Rewrite <archive_path>/index/index.json per the navigation manifest.
+
+    Raises NavigationError / OSError / json.JSONDecodeError on failure.
+    """
+    raise NotImplementedError

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -26,6 +26,7 @@ See ``hacking-index-json.md`` for the verified mechanics.
 import json
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 class NavigationError(Exception):
@@ -195,7 +196,10 @@ def _curate_doc(doc, navigation):
 def curate_navigator(archive_path, navigation):
     """Rewrite <archive_path>/index/index.json per the navigation manifest.
 
-    Raises NavigationError / OSError / json.JSONDecodeError on failure.
+    Also prunes hidden modules from the synthesized landing page
+    (data/documentation.json) so they disappear from the page body, not just
+    the sidebar. Raises NavigationError / OSError / json.JSONDecodeError on
+    failure.
     """
     index_path, doc = _load_index(archive_path)
     _curate_doc(doc, navigation)
@@ -203,6 +207,54 @@ def curate_navigator(archive_path, navigation):
     tmp = index_path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
     os.replace(tmp, index_path)
+
+    _curate_landing_page(archive_path, navigation)
+
+
+def _hidden_paths(navigation):
+    """Lowercased paths the manifest marks hidden."""
+    return {entry["path"].lower() for entry in navigation.get("hidden", [])}
+
+
+def _identifier_path(identifier):
+    """Path component of a topic reference, lowercased.
+
+    ``doc://com.apple.Swift/documentation/Cxx`` → ``/documentation/cxx`` — the
+    same normalized key the manifest uses, so a hidden entry matches its
+    landing-page topic regardless of bundle host or original casing.
+    """
+    return urlparse(identifier).path.lower()
+
+
+def _curate_landing_page(archive_path, navigation):
+    """Remove hidden modules' topics from the synthesized landing page.
+
+    No-op when data/documentation.json is absent or has no topic sections. A
+    topic section left empty after pruning is dropped.
+    """
+    page = Path(archive_path) / "data" / "documentation.json"
+    if not page.is_file():
+        return
+    doc = json.loads(page.read_text())
+    sections = doc.get("topicSections")
+    if not isinstance(sections, list):
+        return
+
+    hidden = _hidden_paths(navigation)
+    kept_sections = []
+    for section in sections:
+        identifiers = [
+            ident for ident in section.get("identifiers", [])
+            if _identifier_path(ident) not in hidden
+        ]
+        if identifiers:
+            section["identifiers"] = identifiers
+            kept_sections.append(section)
+    doc["topicSections"] = kept_sections
+
+    tmp = page.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    os.replace(tmp, page)
 
 
 def dry_run(archive_path, navigation):

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -211,26 +211,33 @@ def curate_navigator(archive_path, navigation):
     _curate_landing_page(archive_path, navigation)
 
 
-def _hidden_paths(navigation):
-    """Lowercased paths the manifest marks hidden."""
-    return {entry["path"].lower() for entry in navigation.get("hidden", [])}
-
-
 def _identifier_path(identifier):
     """Path component of a topic reference, lowercased.
 
     ``doc://com.apple.Swift/documentation/Cxx`` → ``/documentation/cxx`` — the
-    same normalized key the manifest uses, so a hidden entry matches its
+    same normalized key the manifest uses, so a manifest entry matches its
     landing-page topic regardless of bundle host or original casing.
     """
     return urlparse(identifier).path.lower()
 
 
 def _curate_landing_page(archive_path, navigation):
-    """Remove hidden modules' topics from the synthesized landing page.
+    """Rewrite the synthesized landing page (data/documentation.json).
 
-    No-op when data/documentation.json is absent or has no topic sections. A
-    topic section left empty after pruning is dropped.
+    The merged archive's landing page ships with two flat sections — "Modules"
+    and "Tutorials" — driven by docc-merge defaults. This rewrites them in
+    place to mirror the curated sidebar:
+
+      * one ``topicSection`` per ``navigation.groups`` entry, in declared order,
+        titled by the group's ``title``, with identifiers in the group's
+        ``modules`` order;
+      * groups whose modules don't match any identifier on the page are
+        dropped (e.g. a nav module the merge step never surfaced as a card);
+      * each kept identifier's reference is forced to ``kind:"symbol"``,
+        ``role:"collection"`` so all cards render with the same collection icon
+        regardless of how upstream framed the source's root page.
+
+    No-op when ``data/documentation.json`` is absent or has no topic sections.
     """
     page = Path(archive_path) / "data" / "documentation.json"
     if not page.is_file():
@@ -240,21 +247,52 @@ def _curate_landing_page(archive_path, navigation):
     if not isinstance(sections, list):
         return
 
-    hidden = _hidden_paths(navigation)
-    kept_sections = []
+    # Index every identifier on the page by its lowercased path component, so
+    # nav-manifest paths (which match the navigator) line up with landing-page
+    # references regardless of bundle host or original casing.
+    page_by_path = {}
     for section in sections:
-        identifiers = [
-            ident for ident in section.get("identifiers", [])
-            if _identifier_path(ident) not in hidden
-        ]
-        if identifiers:
-            section["identifiers"] = identifiers
-            kept_sections.append(section)
-    doc["topicSections"] = kept_sections
+        for ident in section.get("identifiers", []):
+            page_by_path.setdefault(_identifier_path(ident), ident)
+
+    new_sections = []
+    placed_idents = []
+    for group in navigation.get("groups", []):
+        group_idents = []
+        for entry in group.get("modules", []):
+            ident = page_by_path.get(entry["path"].lower())
+            if ident is not None:
+                group_idents.append(ident)
+        if group_idents:
+            new_sections.append({
+                "title": group["title"],
+                "identifiers": group_idents,
+                "anchor": _section_anchor(group["title"]),
+            })
+            placed_idents.extend(group_idents)
+    doc["topicSections"] = new_sections
+
+    refs = doc.get("references")
+    if isinstance(refs, dict):
+        for ident in placed_idents:
+            ref = refs.get(ident)
+            if isinstance(ref, dict):
+                ref["kind"] = "symbol"
+                ref["role"] = "collection"
 
     tmp = page.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
     os.replace(tmp, page)
+
+
+def _section_anchor(title):
+    """Slug DocC uses for a topicSection's anchor — title with spaces dashed.
+
+    Verified against existing converted pages: ``"Creating a Package"`` →
+    ``"Creating-a-Package"``. Case is preserved; only ASCII whitespace is
+    replaced with a dash. Existing dashes in the title pass through unchanged.
+    """
+    return "-".join(title.split())
 
 
 def dry_run(archive_path, navigation):

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -32,12 +32,164 @@ class NavigationError(Exception):
     """Raised when curation cannot be applied (dangling/unlisted modules, etc.)."""
 
 
+def _entries(navigation):
+    """Yield every (entry, where) across groups and hidden, for validation."""
+    for group in navigation.get("groups", []):
+        for entry in group.get("modules", []):
+            yield entry, "group"
+    for entry in navigation.get("hidden", []):
+        yield entry, "hidden"
+
+
 def validate_navigation(navigation, sources_config):
     """Validate navigation.json against itself and sources.json (offline).
 
     Returns a list of human-readable error strings; empty means valid.
     """
-    raise NotImplementedError
+    errors = []
+
+    if "version" not in navigation:
+        errors.append("navigation.json: missing required 'version'")
+
+    groups = navigation.get("groups", [])
+    if not isinstance(groups, list):
+        errors.append("navigation.json: 'groups' must be a list")
+        groups = []
+    hidden = navigation.get("hidden", [])
+    if not isinstance(hidden, list):
+        errors.append("navigation.json: 'hidden' must be a list")
+
+    # Per-group shape.
+    for i, group in enumerate(groups):
+        if not isinstance(group, dict):
+            errors.append(f"navigation.json: group #{i} must be an object")
+            continue
+        if not group.get("title"):
+            errors.append(f"navigation.json: group #{i} is missing a non-empty 'title'")
+        if not isinstance(group.get("modules", []), list):
+            errors.append(f"navigation.json: group '{group.get('title')}' "
+                          "'modules' must be a list")
+
+    # Per-entry shape, duplicate paths, and source linkage.
+    source_ids = {s.get("id") for s in sources_config.get("sources", [])}
+    referenced_sources = set()
+    seen_paths = set()
+    for entry, where in _entries(navigation):
+        if not isinstance(entry, dict):
+            errors.append(f"navigation.json: a {where} entry must be an object")
+            continue
+        src = entry.get("source")
+        path = entry.get("path")
+        if not src:
+            errors.append(f"navigation.json: a {where} entry is missing 'source'")
+        if not path:
+            errors.append(f"navigation.json: a {where} entry is missing 'path'")
+        if src:
+            referenced_sources.add(src)
+            if src not in source_ids:
+                errors.append(
+                    f"navigation.json: entry references source '{src}' "
+                    "not present in sources.json"
+                )
+        if path:
+            if path in seen_paths:
+                errors.append(
+                    f"navigation.json: path '{path}' appears more than once"
+                )
+            seen_paths.add(path)
+
+    # Completeness: every source must be represented (placed or hidden).
+    for sid in sorted(s for s in source_ids if s):
+        if sid not in referenced_sources:
+            errors.append(
+                f"navigation.json: source '{sid}' from sources.json is not "
+                "represented (place it in a group or list it under 'hidden')"
+            )
+
+    return errors
+
+
+def _group_paths(navigation):
+    """Paths that must be rendered (and therefore must exist in the index)."""
+    return {
+        entry["path"]
+        for group in navigation.get("groups", [])
+        for entry in group.get("modules", [])
+    }
+
+
+def _manifest_paths(navigation):
+    """All paths the manifest accounts for (grouped + hidden)."""
+    return {entry["path"] for entry, _ in _entries(navigation)}
+
+
+def _curate_children(children, navigation):
+    """Return a rewritten children list per the manifest.
+
+    Raises NavigationError on dangling grouped paths, on index modules the
+    manifest neither groups nor hides, or on unexpected pathless nodes.
+    """
+    # Drop any existing group markers so re-running is idempotent, then index
+    # the remaining nodes by path.
+    real_nodes = [c for c in children if c.get("type") != "groupMarker"]
+    path_map = {}
+    for node in real_nodes:
+        path = node.get("path")
+        if not path:
+            raise NavigationError(
+                f"navigator node without a path cannot be curated: {node!r}"
+            )
+        path_map[path] = node
+
+    index_paths = set(path_map)
+
+    # Grouped modules must exist; hidden ones may already be absent (e.g. on a
+    # second curation pass), so they are not required to be present.
+    dangling = _group_paths(navigation) - index_paths
+    if dangling:
+        raise NavigationError(
+            "navigation.json groups modules absent from the merged index: "
+            + ", ".join(sorted(dangling))
+        )
+
+    # Strict total coverage: every index module must be grouped or hidden.
+    unlisted = index_paths - _manifest_paths(navigation)
+    if unlisted:
+        raise NavigationError(
+            "modules present in the merged index are neither grouped nor hidden "
+            "in navigation.json: " + ", ".join(sorted(unlisted))
+        )
+
+    new_children = []
+    for group in navigation.get("groups", []):
+        new_children.append({"type": "groupMarker", "title": group["title"]})
+        for entry in group.get("modules", []):
+            node = path_map[entry["path"]]
+            if entry.get("title"):
+                node["title"] = entry["title"]
+            new_children.append(node)
+    # Hidden entries are simply not re-appended.
+    return new_children
+
+
+def _load_index(archive_path):
+    """Load <archive_path>/index/index.json; raise NavigationError if absent."""
+    index_path = Path(archive_path) / "index" / "index.json"
+    if not index_path.is_file():
+        raise NavigationError(f"index.json not found at {index_path}")
+    return index_path, json.loads(index_path.read_text())
+
+
+def _curate_doc(doc, navigation):
+    """Curate every interface-language tree of a loaded index doc, in place."""
+    for lang, roots in doc.get("interfaceLanguages", {}).items():
+        if not roots:
+            continue
+        root = roots[0]
+        children = root.get("children")
+        if children is None:
+            continue
+        root["children"] = _curate_children(children, navigation)
 
 
 def curate_navigator(archive_path, navigation):
@@ -45,4 +197,26 @@ def curate_navigator(archive_path, navigation):
 
     Raises NavigationError / OSError / json.JSONDecodeError on failure.
     """
-    raise NotImplementedError
+    index_path, doc = _load_index(archive_path)
+    _curate_doc(doc, navigation)
+
+    tmp = index_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    os.replace(tmp, index_path)
+
+
+def dry_run(archive_path, navigation):
+    """Compute the curated navigator WITHOUT modifying the archive.
+
+    Returns a dict mapping each interface language to the list of nodes its
+    sidebar would contain after curation. Raises the same errors as
+    ``curate_navigator`` (dangling/unlisted modules, missing/malformed index)
+    so it doubles as a coverage check while editing ``navigation.json``.
+    """
+    _, doc = _load_index(archive_path)
+    _curate_doc(doc, navigation)
+    return {
+        lang: roots[0].get("children", [])
+        for lang, roots in doc.get("interfaceLanguages", {}).items()
+        if roots
+    }

--- a/scripts/hacking-index-json.md
+++ b/scripts/hacking-index-json.md
@@ -1,0 +1,235 @@
+# Hacking `index/index.json` — DocC Navigator Post-Processing
+
+Swift DocC (as of version 6.3) doesn't yet provide curation and control for ordering
+in the left navigation bar (presented in the web page by `index/index.json`). 
+These notes provide details for future overrides (hacks) to curate the left-hand
+navigation sidebar of a **combined** DocC archive (the one produced by
+`docc merge` in `scripts/build_docs.py`). This leverages the upstream documentation for
+[`RenderIndex.spec.json`](https://github.com/swiftlang/swift-docc/blob/main/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json)
+(June 2026).
+
+## What this file is
+
+`<archive>/index/index.json` is the **render index** consumed by the DocC
+JavaScript front-end to build the navigator (the collapsible tree in the left
+sidebar). It is a *separate, derived* artifact from the page content under
+`data/` — the renderer reads `index/index.json` to draw the tree, and only
+fetches `data/.../*.json` when you click a node. This separation is what makes
+post-processing safe-ish: editing the index changes the **navigation** without
+touching page content.
+
+Other files in `index/` (`data.mdb`, `navigator.index`, `availability.index`)
+are LMDB/binary forms used by other tooling; the JS navigator uses the JSON.
+We do **not** need to regenerate them for the web front-end to reflect changes,
+but be aware they will be stale if something else reads them.
+
+## Top-level shape
+
+```jsonc
+{
+  "schemaVersion": { "major": 0, "minor": 1, "patch": 2 },
+  "references": { ... },                              // present in merged output; leave intact
+  "includedArchiveIdentifiers": ["Inner", "Outer"],   // optional; bundle IDs merged in
+  "interfaceLanguages": {
+    "swift": [ <Node> ],          // <-- length-1 array: a single synthesized ROOT node
+    "occ":   [ ... ]              // other languages, if present, are independent trees
+  }
+}
+```
+
+**All curation happens inside `.interfaceLanguages.swift[0].children[]`.**
+
+`swift[0]` is the synthesized root node — `{ "type": "module", "title":
+"Swift - main", "path": "/documentation", "children": [...] }` (the
+`--synthesized-landing-page-name`). Its **`children`** array holds **one
+`module` node per merged module**, in merge order. That array is the curation
+surface. (In the `main` build it has **36 entries** — see below.)
+
+## The `Node` object
+
+From the spec — a Node's **only required field is `title`**. Recognized fields:
+
+| Field          | Type    | Notes |
+|----------------|---------|-------|
+| `title`        | string  | Required. Display text. |
+| `type`         | string  | Enum (below). Absent on the synthesized root in some cases. |
+| `path`         | string  | Link target, e.g. `/documentation/inner`. Omit for `groupMarker`. |
+| `children`     | array   | Recursive array of `Node`. Builds nesting. |
+| `deprecated`   | boolean | default false |
+| `external`     | boolean | default false |
+| `beta`         | boolean | default false |
+| `icon`         | string  | reference to an `ImageRenderReference` |
+
+### `type` enum (full set)
+
+```
+article, associatedtype, buildSetting, case, collection, class, container,
+dictionarySymbol, enum, extension, func, groupMarker, httpRequest, init,
+languageGroup, learn, macro, method, module, op, overview, project, property,
+propertyListKey, propertyListKeyReference, protocol, resources, root,
+sampleCode, section, struct, subscript, symbol, typealias, union, var
+```
+
+Two types matter most for curation:
+- **`module`** — a top-level documentation source (one per merged archive).
+- **`groupMarker`** — a **label-only** node: it has `title` + `type`, **no
+  `path`, no `children`**. The renderer draws it as a non-clickable section
+  heading among its siblings.
+
+## The three curation operations
+
+### 1. Inject a label (`groupMarker`)
+
+Add a `groupMarker` node anywhere in a `children` array. It labels the siblings
+that follow it, up to the next `groupMarker`. Works at **any depth** — before
+the first module, between modules, or inside a module's own children.
+
+```jsonc
+{ "type": "groupMarker", "title": "Language & Standard Library" }
+```
+
+### 2. Hide a module (filter)
+
+**Delete the module's Node object from `children[]`.** There is no `hidden`
+flag in the spec — removal from the array is how you hide. The page content
+under `data/` and `documentation/` still exists (deep links keep working); it
+just no longer appears in the navigator. If you want it gone entirely, that is
+a separate content-deletion step, not an index edit.
+
+### 3. Group modules together
+
+There are **two** ways, with different UX:
+
+- **(a) Flat labelled sections** — keep modules as siblings, insert
+  `groupMarker`s to head each run. This is what the example archive does. The
+  tree stays one level deep; markers are visual separators.
+
+  ```jsonc
+  "children": [
+    { "type": "groupMarker", "title": "Core" },
+    { "type": "module", "title": "Swift", "path": "/documentation/swift" },
+    { "type": "module", "title": "Standard Library", "path": "..." },
+    { "type": "groupMarker", "title": "Server" },
+    { "type": "module", "title": "ServerGuides", "path": "..." }
+  ]
+  ```
+
+- **(b) True nesting** — wrap a set of module Nodes inside a synthetic parent
+  Node that has its own `title` + `children`. The navigator renders this as a
+  collapsible group. The parent can be a plain container; give it a `path` only
+  if you want it clickable (it would need real content to land on). Nesting
+  modules under a pathless parent is **off the beaten path** for DocC and should
+  be validated in the actual renderer before relying on it.
+
+  ```jsonc
+  "children": [
+    {
+      "title": "Server-Side Swift",
+      "type": "groupMarker",   // or a container; verify rendering
+      "children": [ <module>, <module> ]
+    }
+  ]
+  ```
+
+  Note: a `groupMarker` with `children` is *not* in the example; the safe,
+  proven pattern is **(a) flat markers**. Prefer (a) unless collapsibility is a
+  hard requirement and you've confirmed (b) renders.
+
+## Where this slots into the combined build
+
+In `scripts/build_docs.py`:
+
+1. Each source in `scripts/sources.json` builds to its own `.doccarchive`.
+2. `merge_archives()` runs `docc merge ... --synthesized-landing-page-name ...
+   --synthesized-landing-page-topics-style list` → produces the combined
+   archive with a fresh `index/index.json`.
+3. `transform_static_hosting()` bakes the hosting base path.
+
+**The post-processing hook belongs between steps 2 and 3** — i.e. in
+`_finalize_combined_archive`, after `merge_archives()` returns and before
+`transform_static_hosting()`. The merged `index.json` exists at that point, and
+curating before the static-hosting transform means the transform consumes the
+already-curated tree. A `curate_navigator(archive, config)` function would: load
+`index/index.json`, walk `interfaceLanguages.<lang>[0].children`, then
+drop/reorder/relabel module nodes per config, and write the file back (preserve
+`schemaVersion`, `references`, `includedArchiveIdentifiers`, and top-level key
+order; write atomically).
+
+**Real output, verified.** A current `main` merge produces an `index/`
+directory containing **only `index.json`** (~4.9 MB) — no `data.mdb` /
+`navigator.index` / `availability.index`. Its `swift[0].children` has **36
+module nodes**, many of which are exactly the stdlib-internal noise to hide:
+
+```
+Cxx, CxxStdlib, Distributed, OSLogTestHelper, Observation, RegexBuilder,
+Runtime, RuntimeUnittest, StdlibUnittest, StdlibUnittestFoundationExtras,
+Swift, SwiftOnoneSupport, SwiftPrivate, SwiftPrivateLibcExtras,
+SwiftPrivateThreadExtras, SwiftReflectionTest, Synchronization,
+_Builtin_float, _Differentiation, _RegexParser, _Volatile,
+The Swift Programming Language (6.3), Migrating to Swift 6,
+Swift compiler diagnostics, Swift Package Manager, PackageDescription,
+PackagePlugin, Testing, DocC, Embedded Swift, ...
+```
+
+Note `Swift Package Manager` / `PackageDescription` / `PackagePlugin` are three
+separate module nodes from the single `swiftpm` source — multi-target sources
+fan out, so curation must address modules by their rendered title/path, not by
+`sources.json` id.
+
+### Matching modules to sources
+
+Module Nodes are keyed by `title` and `path` (`/documentation/<module>`,
+lowercased). `sources.json` entries are keyed by `id` and produce modules named
+by their `docc_catalog`/`targets`. The mapping from a `sources.json` `id` to the
+resulting module `path`/`title` is **not 1:1 or guaranteed** — a single source
+with multiple `targets` (e.g. `swiftpm` →
+`PackageManagerDocs`/`PackageDescription`/`PackagePlugin`) yields multiple
+module nodes. Any curation config must therefore address modules by their
+**rendered title/path**, and ideally be validated against the actual merged
+index rather than assumed from `sources.json` alone.
+
+## Second surface: the synthesized landing page
+
+`index/index.json` only drives the **sidebar**. The body of the synthesized
+landing page (`/documentation/`) is rendered from **`data/documentation.json`**,
+whose `topicSections[]` list every module as a card via `identifiers` like
+`doc://com.apple.Swift/documentation/Cxx`. Hiding a module from the sidebar does
+**not** remove it here — you must prune these too, or hidden modules still show
+as cards on the main page.
+
+Match an identifier to a manifest path by its **path component, lowercased**:
+`urlparse("doc://com.apple.Swift/documentation/Cxx").path.lower()` →
+`/documentation/cxx`, which equals the manifest `path` regardless of bundle host
+or original casing. Drop hidden identifiers from each section's `identifiers`,
+and drop a section that ends up empty. Leave `references` intact (unlinked
+entries are harmless). Our `curate_navigator()` does both surfaces in one pass.
+
+## Gotchas
+
+- **Idempotency / order:** merge order determines initial child order; reordering
+  must be explicit in the curation step, not assumed from `sources.json` order.
+- **Stale binary indexes — not a concern for our pipeline.** The real `docc
+  merge` output's `index/` holds only `index.json`, so a JSON edit is the whole
+  job. (The `~` example archive's `data.mdb` / `navigator.index` /
+  `availability.index` are an artifact of how that example was packaged.) If a
+  future toolchain *does* emit those alongside the merged `index.json`, delete
+  them after curating rather than leave them stale — a missing binary index
+  degrades to the JSON navigator, a stale one could resurrect hidden modules.
+- **`includedArchiveIdentifiers`** is informational; leave it intact.
+- **Schema drift:** the spec lives upstream and evolves. Re-check the `type`
+  enum and required fields against the pinned swift-docc version when builds
+  start using a newer toolchain.
+- **Validate in the renderer:** the spec permits many shapes the DocC JS
+  navigator may render imperfectly (esp. nested modules / `groupMarker` with
+  children). Always preview the combined archive after curating.
+
+## Quick manual recipe
+
+```bash
+# Pretty-print the curation surface
+python3 -c "import json; d=json.load(open('index/index.json')); \
+print(json.dumps(d['interfaceLanguages']['swift'][0]['children'], indent=2))"
+```
+
+Edit `children[]` (drop nodes to hide; insert `{type:groupMarker,title:...}`
+to label/group), write back, then re-preview the archive.

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "groups": [
+    {
+      "title": "The Swift Language",
+      "modules": [
+        { "source": "swift-stdlib", "path": "/documentation/swift" },
+        { "source": "swift-book", "path": "/documentation/the-swift-programming-language" },
+        { "source": "swift-migration-guide", "path": "/documentation/migrationguide" },
+        { "source": "compiler-diagnostics", "path": "/documentation/diagnostics" }
+      ]
+    },
+    {
+      "title": "Package Manager",
+      "modules": [
+        { "source": "swiftpm", "path": "/documentation/packagemanagerdocs", "title": "Swift Package Manager" },
+        { "source": "swiftpm", "path": "/documentation/packagedescription" },
+        { "source": "swiftpm", "path": "/documentation/packageplugin" }
+      ]
+    },
+    {
+      "title": "Testing",
+      "modules": [
+        { "source": "swift-testing", "path": "/documentation/testing" }
+      ]
+    },
+    {
+      "title": "Server-Side Swift",
+      "modules": [
+        { "source": "server-guides", "path": "/documentation/serverguides" },
+        { "source": "swift-server-todos-tutorial", "path": "/tutorials/getting-started-swift-server" }
+      ]
+    },
+    {
+      "title": "Tools",
+      "modules": [
+        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Swiftly" },
+        { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "Swift for VS Code" },
+        { "source": "docc-documentation", "path": "/documentation/docc" }
+      ]
+    },
+    {
+      "title": "Platforms",
+      "modules": [
+        { "source": "embedded-swift", "path": "/documentation/embeddedswift" },
+        { "source": "swift-wasm", "path": "/documentation/wasmguide" },
+        { "source": "swift-android", "path": "/documentation/swiftandroid" }
+      ]
+    }
+  ],
+  "hidden": [
+    { "source": "swift-stdlib", "path": "/documentation/cxx" },
+    { "source": "swift-stdlib", "path": "/documentation/cxxstdlib" },
+    { "source": "swift-stdlib", "path": "/documentation/distributed" },
+    { "source": "swift-stdlib", "path": "/documentation/oslogtesthelper" },
+    { "source": "swift-stdlib", "path": "/documentation/observation" },
+    { "source": "swift-stdlib", "path": "/documentation/regexbuilder" },
+    { "source": "swift-stdlib", "path": "/documentation/runtime" },
+    { "source": "swift-stdlib", "path": "/documentation/runtimeunittest" },
+    { "source": "swift-stdlib", "path": "/documentation/stdlibunittest" },
+    { "source": "swift-stdlib", "path": "/documentation/stdlibunittestfoundationextras" },
+    { "source": "swift-stdlib", "path": "/documentation/swiftononesupport" },
+    { "source": "swift-stdlib", "path": "/documentation/swiftprivate" },
+    { "source": "swift-stdlib", "path": "/documentation/swiftprivatelibcextras" },
+    { "source": "swift-stdlib", "path": "/documentation/swiftprivatethreadextras" },
+    { "source": "swift-stdlib", "path": "/documentation/swiftreflectiontest" },
+    { "source": "swift-stdlib", "path": "/documentation/synchronization" },
+    { "source": "swift-stdlib", "path": "/documentation/_builtin_float" },
+    { "source": "swift-stdlib", "path": "/documentation/_differentiation" },
+    { "source": "swift-stdlib", "path": "/documentation/_regexparser" },
+    { "source": "swift-stdlib", "path": "/documentation/_volatile" }
+  ]
+}

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -34,9 +34,9 @@
     {
       "title": "Tools",
       "modules": [
-        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Swiftly" },
+        { "source": "docc-documentation", "path": "/documentation/docc" },
         { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "Swift for VS Code" },
-        { "source": "docc-documentation", "path": "/documentation/docc" }
+        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Swiftly" }
       ]
     },
     {

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1829,20 +1829,34 @@ class ValidateNavigationCLI(unittest.TestCase):
             self.assertEqual(validate_navigation_cli.main(argv), 1)
 
 
-def _write_landing_page(archive, sections):
+def _write_landing_page(archive, sections, references=None):
     """Write a minimal synthesized landing page (data/documentation.json).
 
-    `sections` is a list of (title, [identifiers]).
+    `sections` is a list of (title, [identifiers]). When `references` is
+    omitted, every identifier appearing in any section is given a stock
+    article-shaped reference, mirroring how docc emits article-kind cards by
+    default for standalone .docc catalogs.
     """
     data = archive / "data"
     data.mkdir(parents=True, exist_ok=True)
+    if references is None:
+        references = {}
+        for _, ids in sections:
+            for ident in ids:
+                references.setdefault(ident, {
+                    "identifier": ident,
+                    "kind": "article",
+                    "title": ident.rsplit("/", 1)[-1],
+                    "type": "topic",
+                    "url": "/documentation/x",
+                })
     doc = {
         "identifier": {"url": "doc://X/documentation", "interfaceLanguage": "swift"},
         "kind": "symbol",
         "topicSections": [
             {"title": t, "identifiers": list(ids)} for t, ids in sections
         ],
-        "references": {},
+        "references": references,
     }
     (data / "documentation.json").write_text(json.dumps(doc, indent=2) + "\n")
 
@@ -1856,10 +1870,16 @@ class CurateLandingPage(unittest.TestCase):
     def _nav(self):
         return {
             "version": 1,
-            "groups": [{"title": "Language", "modules": [
-                {"source": "a", "path": "/documentation/swift"},
-                {"source": "a", "path": "/documentation/testing"},
-            ]}],
+            "groups": [
+                {"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                    {"source": "a", "path": "/documentation/testing"},
+                ]},
+                {"title": "Server-Side Swift", "modules": [
+                    {"source": "a", "path": "/documentation/serverguides"},
+                    {"source": "a", "path": "/tutorials/getting-started-swift-server"},
+                ]},
+            ],
             "hidden": [{"source": "a", "path": "/documentation/internal"}],
         }
 
@@ -1868,41 +1888,116 @@ class CurateLandingPage(unittest.TestCase):
             _module("Swift", "/documentation/swift"),
             _module("Internal", "/documentation/internal"),
             _module("Testing", "/documentation/testing"),
+            _module("Server Guides", "/documentation/serverguides"),
+            _module("Getting Started", "/tutorials/getting-started-swift-server"),
         ]
 
-    def test_hidden_modules_removed_from_landing_page(self):
+    def _docc_merge_landing(self):
+        """Approximate what docc merge produces: one Modules + one Tutorials."""
+        return [
+            ("Modules", [
+                "doc://Test/documentation/Swift",
+                "doc://Test/documentation/Internal",
+                "doc://Test/documentation/Testing",
+                "doc://Test/documentation/ServerGuides",
+            ]),
+            ("Tutorials", [
+                "doc://Test/tutorials/getting-started-swift-server",
+            ]),
+        ]
+
+    def test_landing_page_sections_match_nav_groups(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            _write_landing_page(archive, self._docc_merge_landing())
+            curate_navigator.curate_navigator(archive, self._nav())
+            sections = _landing_sections(archive)
+
+        # One section per nav group, in nav order.
+        self.assertEqual([t for t, _ in sections],
+                         ["Language", "Server-Side Swift"])
+        # Identifiers in declared nav order; hidden module dropped from Language.
+        self.assertEqual(sections[0][1], [
+            "doc://Test/documentation/Swift",
+            "doc://Test/documentation/Testing",
+        ])
+        # Tutorials get folded into Server-Side Swift via nav-group placement.
+        self.assertEqual(sections[1][1], [
+            "doc://Test/documentation/ServerGuides",
+            "doc://Test/tutorials/getting-started-swift-server",
+        ])
+
+    def test_hidden_modules_dropped_from_landing_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            _write_landing_page(archive, self._docc_merge_landing())
+            curate_navigator.curate_navigator(archive, self._nav())
+            sections = _landing_sections(archive)
+
+        all_ids = [i for _, ids in sections for i in ids]
+        self.assertNotIn("doc://Test/documentation/Internal", all_ids)
+
+    def test_group_with_no_matches_is_dropped(self):
+        nav = {
+            "version": 1,
+            "groups": [
+                {"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                ]},
+                # Group whose modules don't appear in the landing page (e.g. the
+                # navigator references a path the merge step didn't surface).
+                {"title": "Empty Group", "modules": [
+                    {"source": "a", "path": "/documentation/never-on-page"},
+                ]},
+            ],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [
+                _module("Swift", "/documentation/swift"),
+                _module("NeverOnPage", "/documentation/never-on-page"),
+            ])
+            _write_landing_page(archive, [
+                ("Modules", ["doc://Test/documentation/Swift"]),
+            ])
+            curate_navigator.curate_navigator(archive, nav)
+            titles = [t for t, _ in _landing_sections(archive)]
+
+        self.assertEqual(titles, ["Language"])
+
+    def test_overwrites_kept_reference_kind_and_role(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            _write_landing_page(archive, self._docc_merge_landing())
+            curate_navigator.curate_navigator(archive, self._nav())
+            doc = json.loads((archive / "data" / "documentation.json").read_text())
+            refs = doc["references"]
+
+        for ident in (
+            "doc://Test/documentation/Swift",
+            "doc://Test/documentation/Testing",
+            "doc://Test/documentation/ServerGuides",
+            "doc://Test/tutorials/getting-started-swift-server",
+        ):
+            self.assertEqual(refs[ident]["kind"], "symbol", ident)
+            self.assertEqual(refs[ident]["role"], "collection", ident)
+
+    def test_hidden_reference_kind_and_role_unchanged(self):
         with tempfile.TemporaryDirectory() as tmp:
             archive = _make_index(Path(tmp), self._index_children())
             _write_landing_page(archive, [
                 ("Modules", [
                     "doc://Test/documentation/Swift",
-                    "doc://Test/documentation/Internal",  # hidden, mixed case
-                    "doc://Test/documentation/Testing",
+                    "doc://Test/documentation/Internal",
                 ]),
-                ("Tutorials", ["doc://Test/tutorials/getting-started"]),
             ])
             curate_navigator.curate_navigator(archive, self._nav())
-            sections = dict(_landing_sections(archive))
+            doc = json.loads((archive / "data" / "documentation.json").read_text())
+            refs = doc["references"]
 
-        self.assertEqual(sections["Modules"], [
-            "doc://Test/documentation/Swift",
-            "doc://Test/documentation/Testing",
-        ])
-        # Non-hidden sections are untouched.
-        self.assertEqual(sections["Tutorials"], ["doc://Test/tutorials/getting-started"])
-
-    def test_section_emptied_by_hiding_is_dropped(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            archive = _make_index(Path(tmp), self._index_children())
-            _write_landing_page(archive, [
-                ("Modules", ["doc://Test/documentation/Swift",
-                             "doc://Test/documentation/Testing"]),
-                ("Internal Stuff", ["doc://Test/documentation/Internal"]),
-            ])
-            curate_navigator.curate_navigator(archive, self._nav())
-            titles = [t for t, _ in _landing_sections(archive)]
-
-        self.assertEqual(titles, ["Modules"])
+        # Hidden reference's fields are not touched (kind stays "article").
+        self.assertEqual(refs["doc://Test/documentation/Internal"]["kind"], "article")
+        self.assertNotIn("role", refs["doc://Test/documentation/Internal"])
 
     def test_missing_landing_page_is_noop(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1915,11 +2010,7 @@ class CurateLandingPage(unittest.TestCase):
     def test_landing_page_idempotent(self):
         with tempfile.TemporaryDirectory() as tmp:
             archive = _make_index(Path(tmp), self._index_children())
-            _write_landing_page(archive, [
-                ("Modules", ["doc://Test/documentation/Swift",
-                             "doc://Test/documentation/Internal",
-                             "doc://Test/documentation/Testing"]),
-            ])
+            _write_landing_page(archive, self._docc_merge_landing())
             page = archive / "data" / "documentation.json"
             curate_navigator.curate_navigator(archive, self._nav())
             once = page.read_bytes()

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1168,6 +1168,117 @@ class FinalizeCombinedArchive(unittest.TestCase):
         self.assertEqual(failed, [])
 
 
+class InjectCustomTemplatesIntoStubs(unittest.TestCase):
+    """Workaround for swiftlang/swift-docc#1532: see build_docs function docstring."""
+
+    ANCHOR = '<body data-color-scheme="auto">'
+
+    def _make_archive(self, root, header_text, footer_text):
+        """Build a fake archive tree with a templated root and stripped subroute stubs."""
+        archive = root / "main"
+        archive.mkdir()
+        # Common templates the function reads from.
+        common = root / "common"
+        common.mkdir()
+        (common / "header.html").write_text(header_text)
+        (common / "footer.html").write_text(footer_text)
+        # Root index.html already contains the templates (from docc convert/merge).
+        root_index = archive / "index.html"
+        root_index.write_text(
+            f'<!doctype html><html><body data-color-scheme="auto">'
+            f'<template id="custom-footer">{footer_text}</template>'
+            f'<template id="custom-header">{header_text}</template>'
+            f'<div id="app"></div></body></html>'
+        )
+        # Stripped subroute stubs from transform-for-static-hosting.
+        for sub in (
+            "documentation/index.html",
+            "documentation/foo/index.html",
+            "documentation/foo/bar/index.html",
+            "tutorials/baz/index.html",
+        ):
+            sub_path = archive / sub
+            sub_path.parent.mkdir(parents=True, exist_ok=True)
+            sub_path.write_text(
+                '<!doctype html><html><body data-color-scheme="auto">'
+                '<div id="app"></div></body></html>'
+            )
+        return archive, common
+
+    def test_patches_subroute_stubs_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive, common = self._make_archive(Path(tmp), "HDR", "FTR")
+            patched = build_docs.inject_custom_templates_into_stubs(archive, common)
+            self.assertEqual(patched, 4)
+            for sub in (
+                "documentation/index.html",
+                "documentation/foo/index.html",
+                "documentation/foo/bar/index.html",
+                "tutorials/baz/index.html",
+            ):
+                text = (archive / sub).read_text()
+                self.assertIn('<template id="custom-header">HDR</template>', text)
+                self.assertIn('<template id="custom-footer">FTR</template>', text)
+
+    def test_root_index_is_left_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive, common = self._make_archive(Path(tmp), "HDR", "FTR")
+            before = (archive / "index.html").read_text()
+            build_docs.inject_custom_templates_into_stubs(archive, common)
+            self.assertEqual((archive / "index.html").read_text(), before)
+
+    def test_idempotent_when_run_twice(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive, common = self._make_archive(Path(tmp), "HDR", "FTR")
+            first = build_docs.inject_custom_templates_into_stubs(archive, common)
+            after_first = {
+                sub: (archive / sub).read_text()
+                for sub in ("documentation/index.html", "tutorials/baz/index.html")
+            }
+            second = build_docs.inject_custom_templates_into_stubs(archive, common)
+            self.assertEqual(first, 4)
+            self.assertEqual(second, 0)
+            for sub, text in after_first.items():
+                self.assertEqual((archive / sub).read_text(), text)
+
+    def test_skips_files_without_anchor(self):
+        """If DocC ever fixes #1532 and emits a different shell shape, leave it alone."""
+        with tempfile.TemporaryDirectory() as tmp:
+            archive, common = self._make_archive(Path(tmp), "HDR", "FTR")
+            no_anchor = archive / "documentation" / "no-anchor" / "index.html"
+            no_anchor.parent.mkdir(parents=True, exist_ok=True)
+            original = "<!doctype html><html><body><div id=\"app\"></div></body></html>"
+            no_anchor.write_text(original)
+            build_docs.inject_custom_templates_into_stubs(archive, common)
+            self.assertEqual(no_anchor.read_text(), original)
+
+    def test_no_subroute_stubs_returns_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "main"
+            archive.mkdir()
+            (archive / "index.html").write_text(
+                '<body data-color-scheme="auto">'
+                '<template id="custom-header">HDR</template>'
+                '<template id="custom-footer">FTR</template></body>'
+            )
+            common = Path(tmp) / "common"
+            common.mkdir()
+            (common / "header.html").write_text("HDR")
+            (common / "footer.html").write_text("FTR")
+            patched = build_docs.inject_custom_templates_into_stubs(archive, common)
+            self.assertEqual(patched, 0)
+
+    def test_template_ordering_matches_docc_convert(self):
+        """custom-footer comes before custom-header — same order docc convert emits."""
+        with tempfile.TemporaryDirectory() as tmp:
+            archive, common = self._make_archive(Path(tmp), "HDR", "FTR")
+            build_docs.inject_custom_templates_into_stubs(archive, common)
+            text = (archive / "documentation" / "index.html").read_text()
+            footer_pos = text.index('<template id="custom-footer">')
+            header_pos = text.index('<template id="custom-header">')
+            self.assertLess(footer_pos, header_pos)
+
+
 class CleanPackageBuildDirs(unittest.TestCase):
     def test_removes_build_dir_for_local_source(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import build_docs  # noqa: E402
 import curate_navigator  # noqa: E402
 import strip_availability  # noqa: E402
+import validate_navigation as validate_navigation_cli  # noqa: E402
 
 
 def _validate(config):
@@ -1167,6 +1168,88 @@ class FinalizeCombinedArchive(unittest.TestCase):
         self.assertEqual(succeeded, ["combined-merge", "static-hosting-transform"])
         self.assertEqual(failed, [])
 
+    def _merge_writes_index(self, modules):
+        """Build a fake subprocess.run that writes a merged index.json on merge.
+
+        `modules` is a list of (title, path); merge writes them as the
+        synthesized root's children. The transform step succeeds by producing
+        an output archive at --output-path.
+        """
+        def fake_run(cmd, **kw):
+            out_idx = cmd.index("--output-path") + 1
+            out = Path(cmd[out_idx])
+            out.mkdir(parents=True, exist_ok=True)
+            if "merge" in cmd:
+                (out / "index").mkdir(parents=True, exist_ok=True)
+                doc = {
+                    "schemaVersion": {"major": 0, "minor": 1, "patch": 2},
+                    "interfaceLanguages": {
+                        "swift": [{
+                            "title": "Swift - main",
+                            "children": [
+                                {"type": "module", "title": t, "path": p}
+                                for t, p in modules
+                            ],
+                            "path": "/documentation",
+                            "type": "module",
+                        }]
+                    },
+                }
+                (out / "index" / "index.json").write_text(json.dumps(doc) + "\n")
+            else:
+                (out / "index.html").write_text("transformed")
+            return subprocess.CompletedProcess(cmd, 0)
+        return fake_run
+
+    def test_curation_failure_records_navigator_curation(self):
+        nav = {
+            "version": 1,
+            "groups": [{"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+            ]}],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+            # Index has an extra module the manifest neither groups nor hides.
+            fake_run = self._merge_writes_index([
+                ("Swift", "/documentation/swift"),
+                ("Extra", "/documentation/extra"),
+            ])
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                succeeded, failed = build_docs._finalize_combined_archive(
+                    [archive], tmp_path, "main", ["docc"], prior_failed=[],
+                    navigation=nav,
+                )
+        self.assertEqual(succeeded, ["combined-merge"])
+        self.assertEqual(failed, ["navigator-curation"])
+
+    def test_curation_success_records_navigator_curation(self):
+        nav = {
+            "version": 1,
+            "groups": [{"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+            ]}],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+            fake_run = self._merge_writes_index([("Swift", "/documentation/swift")])
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                succeeded, failed = build_docs._finalize_combined_archive(
+                    [archive], tmp_path, "main", ["docc"], prior_failed=[],
+                    navigation=nav,
+                )
+        self.assertEqual(
+            succeeded,
+            ["combined-merge", "navigator-curation", "static-hosting-transform"],
+        )
+        self.assertEqual(failed, [])
+
 
 class InjectCustomTemplatesIntoStubs(unittest.TestCase):
     """Workaround for swiftlang/swift-docc#1532: see build_docs function docstring."""
@@ -1417,6 +1500,332 @@ class AssembleInSourceOrder(unittest.TestCase):
         archives, entries = build_docs.assemble_in_source_order({}, num_sources=3)
         self.assertEqual(archives, [])
         self.assertEqual(entries, [])
+
+
+# ---------------------------------------------------------------------------
+# Navigator curation (curate_navigator.py)
+# ---------------------------------------------------------------------------
+
+def _module(title, path):
+    """Build a module navigator node (key order mirrors real docc output)."""
+    return {"type": "module", "title": title, "path": path}
+
+
+def _make_index(tmp_path, children, langs=("swift",)):
+    """Write a minimal merged index.json into a fresh archive; return its Path.
+
+    Mirrors the real shape: top-level schemaVersion / references /
+    includedArchiveIdentifiers / interfaceLanguages, with a single synthesized
+    root module per language whose `children` is the curation surface.
+    """
+    archive = tmp_path / "combined.doccarchive"
+    (archive / "index").mkdir(parents=True)
+    doc = {
+        "schemaVersion": {"major": 0, "minor": 1, "patch": 2},
+        "references": {"keep": "me"},
+        "includedArchiveIdentifiers": ["A", "B"],
+        "interfaceLanguages": {
+            lang: [
+                {
+                    "title": "Swift - main",
+                    "children": [dict(c) for c in children],
+                    "path": "/documentation",
+                    "type": "module",
+                }
+            ]
+            for lang in langs
+        },
+    }
+    (archive / "index" / "index.json").write_text(json.dumps(doc, indent=2) + "\n")
+    return archive
+
+
+def _children_of(archive, lang="swift"):
+    doc = json.loads((archive / "index" / "index.json").read_text())
+    return doc["interfaceLanguages"][lang][0]["children"]
+
+
+class ValidateNavigation(unittest.TestCase):
+    SOURCES = {"version": "main", "sources": [{"id": "a"}, {"id": "b"}]}
+
+    def _nav(self, **over):
+        nav = {
+            "version": 1,
+            "groups": [
+                {"title": "Lang", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                ]},
+            ],
+            "hidden": [
+                {"source": "b", "path": "/documentation/internal"},
+            ],
+        }
+        nav.update(over)
+        return nav
+
+    def test_valid_navigation_has_no_errors(self):
+        self.assertEqual(
+            curate_navigator.validate_navigation(self._nav(), self.SOURCES), []
+        )
+
+    def test_unknown_source_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "ghost", "path": "/documentation/swift"},
+            ]},
+        ], hidden=[{"source": "b", "path": "/documentation/internal"}])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("ghost" in e for e in errors), errors)
+
+    def test_source_missing_from_navigation_is_reported(self):
+        # 'b' is in sources.json but referenced nowhere in navigation.
+        nav = self._nav(hidden=[])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("b" in e for e in errors), errors)
+
+    def test_duplicate_path_is_reported(self):
+        nav = self._nav(
+            groups=[{"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+            ]}],
+            hidden=[
+                {"source": "b", "path": "/documentation/swift"},
+            ],
+        )
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("/documentation/swift" in e for e in errors), errors)
+
+    def test_group_without_title_is_reported(self):
+        nav = self._nav(groups=[{"title": "", "modules": [
+            {"source": "a", "path": "/documentation/swift"},
+        ]}])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(errors)
+
+    def test_malformed_entry_missing_path_is_reported(self):
+        nav = self._nav(groups=[{"title": "Lang", "modules": [
+            {"source": "a"},
+        ]}])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(errors)
+
+
+class CurateNavigator(unittest.TestCase):
+    def _nav(self):
+        return {
+            "version": 1,
+            "groups": [
+                {"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift",
+                     "title": "The Swift Language"},
+                    {"source": "b", "path": "/documentation/testing"},
+                ]},
+            ],
+            "hidden": [
+                {"source": "a", "path": "/documentation/internal"},
+            ],
+        }
+
+    def _happy_children(self):
+        return [
+            _module("Swift", "/documentation/swift"),
+            _module("Internal", "/documentation/internal"),
+            _module("Testing", "/documentation/testing"),
+        ]
+
+    def test_groups_hides_and_orders(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._happy_children())
+            curate_navigator.curate_navigator(archive, self._nav())
+            kids = _children_of(archive)
+
+        self.assertEqual(len(kids), 3)
+        self.assertEqual(kids[0], {"type": "groupMarker", "title": "Language"})
+        self.assertNotIn("path", kids[0])
+        # Manifest order: swift (renamed) then testing; internal hidden.
+        self.assertEqual(kids[1]["path"], "/documentation/swift")
+        self.assertEqual(kids[1]["title"], "The Swift Language")
+        self.assertEqual(kids[2]["path"], "/documentation/testing")
+        self.assertFalse(any(k.get("path") == "/documentation/internal" for k in kids))
+
+    def test_dangling_manifest_path_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [_module("Swift", "/documentation/swift")])
+            nav = {
+                "version": 1,
+                "groups": [{"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                    {"source": "a", "path": "/documentation/missing"},
+                ]}],
+                "hidden": [],
+            }
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.curate_navigator(archive, nav)
+
+    def test_unlisted_index_module_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [
+                _module("Swift", "/documentation/swift"),
+                _module("Extra", "/documentation/extra"),
+            ])
+            nav = {
+                "version": 1,
+                "groups": [{"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                ]}],
+                "hidden": [],
+            }
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.curate_navigator(archive, nav)
+
+    def test_preserves_top_level_keys_and_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._happy_children())
+            curate_navigator.curate_navigator(archive, self._nav())
+            doc = json.loads((archive / "index" / "index.json").read_text())
+
+        self.assertEqual(
+            list(doc.keys()),
+            ["schemaVersion", "references", "includedArchiveIdentifiers",
+             "interfaceLanguages"],
+        )
+        self.assertEqual(doc["references"], {"keep": "me"})
+        self.assertEqual(doc["includedArchiveIdentifiers"], ["A", "B"])
+        self.assertEqual(doc["schemaVersion"], {"major": 0, "minor": 1, "patch": 2})
+
+    def test_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._happy_children())
+            index = archive / "index" / "index.json"
+            curate_navigator.curate_navigator(archive, self._nav())
+            once = index.read_bytes()
+            curate_navigator.curate_navigator(archive, self._nav())
+            twice = index.read_bytes()
+        self.assertEqual(once, twice)
+
+    def test_curates_each_interface_language(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._happy_children(),
+                                  langs=("swift", "occ"))
+            curate_navigator.curate_navigator(archive, self._nav())
+            for lang in ("swift", "occ"):
+                kids = _children_of(archive, lang)
+                self.assertEqual(kids[0]["type"], "groupMarker")
+                self.assertFalse(
+                    any(k.get("path") == "/documentation/internal" for k in kids)
+                )
+
+    def test_missing_index_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "empty.doccarchive"
+            archive.mkdir()
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.curate_navigator(archive, self._nav())
+
+    def test_malformed_index_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "bad.doccarchive"
+            (archive / "index").mkdir(parents=True)
+            (archive / "index" / "index.json").write_text("{not json")
+            with self.assertRaises(json.JSONDecodeError):
+                curate_navigator.curate_navigator(archive, self._nav())
+
+
+class CurateNavigatorDryRun(unittest.TestCase):
+    def _nav(self):
+        return {
+            "version": 1,
+            "groups": [{"title": "Language", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+            ]}],
+            "hidden": [{"source": "a", "path": "/documentation/internal"}],
+        }
+
+    def test_returns_curated_children_without_writing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [
+                _module("Swift", "/documentation/swift"),
+                _module("Internal", "/documentation/internal"),
+            ])
+            index = archive / "index" / "index.json"
+            before = index.read_bytes()
+            result = curate_navigator.dry_run(archive, self._nav())
+            after = index.read_bytes()
+
+        self.assertEqual(before, after)  # archive untouched
+        kids = result["swift"]
+        self.assertEqual(kids[0], {"type": "groupMarker", "title": "Language"})
+        self.assertEqual([k.get("path") for k in kids[1:]], ["/documentation/swift"])
+
+    def test_unlisted_module_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [
+                _module("Swift", "/documentation/swift"),
+                _module("Extra", "/documentation/extra"),
+            ])
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.dry_run(archive, self._nav())
+
+
+class ValidateNavigationCLI(unittest.TestCase):
+    def _setup(self, tmp, nav, sources, archive_modules=None):
+        """Write nav + sources files (and optionally an archive); return argv."""
+        tmp = Path(tmp)
+        nav_path = tmp / "navigation.json"
+        src_path = tmp / "sources.json"
+        nav_path.write_text(json.dumps(nav))
+        src_path.write_text(json.dumps(sources))
+        argv = ["--navigation", str(nav_path), "--sources", str(src_path)]
+        if archive_modules is not None:
+            archive = _make_index(tmp, [_module(t, p) for t, p in archive_modules])
+            argv += ["--archive", str(archive)]
+        return argv
+
+    SOURCES = {"version": "main", "sources": [{"id": "a"}, {"id": "b"}]}
+
+    def _nav(self):
+        return {
+            "version": 1,
+            "groups": [{"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+            ]}],
+            "hidden": [{"source": "b", "path": "/documentation/internal"}],
+        }
+
+    def test_valid_without_archive_returns_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = self._setup(tmp, self._nav(), self.SOURCES)
+            self.assertEqual(validate_navigation_cli.main(argv), 0)
+
+    def test_unknown_source_returns_1(self):
+        nav = self._nav()
+        nav["groups"][0]["modules"][0]["source"] = "ghost"
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = self._setup(tmp, nav, self.SOURCES)
+            self.assertEqual(validate_navigation_cli.main(argv), 1)
+
+    def test_archive_fully_covered_returns_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = self._setup(
+                tmp, self._nav(), self.SOURCES,
+                archive_modules=[
+                    ("Swift", "/documentation/swift"),
+                    ("Internal", "/documentation/internal"),
+                ],
+            )
+            self.assertEqual(validate_navigation_cli.main(argv), 0)
+
+    def test_archive_with_unlisted_module_returns_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = self._setup(
+                tmp, self._nav(), self.SOURCES,
+                archive_modules=[
+                    ("Swift", "/documentation/swift"),
+                    ("Internal", "/documentation/internal"),
+                    ("Extra", "/documentation/extra"),
+                ],
+            )
+            self.assertEqual(validate_navigation_cli.main(argv), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1028,6 +1028,44 @@ class CollectGitMetadata(unittest.TestCase):
         self.assertEqual(commit, "unknown")
 
 
+class MergeArchives(unittest.TestCase):
+    def _capture_merge_cmd(self, version):
+        """Run merge_archives with a stubbed subprocess and return the cmd."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+            output = tmp_path / version
+            captured = {}
+
+            def fake_run(cmd, **kw):
+                captured["cmd"] = cmd
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                build_docs.merge_archives(
+                    [archive], output, ["docc"],
+                    landing_page_name=f"Swift - {version}",
+                )
+            return captured["cmd"]
+
+    def test_passes_landing_page_name_and_list_style(self):
+        cmd = self._capture_merge_cmd("6.2")
+
+        self.assertIn("--synthesized-landing-page-name", cmd)
+        name_idx = cmd.index("--synthesized-landing-page-name") + 1
+        self.assertEqual(cmd[name_idx], "Swift - 6.2")
+
+        self.assertIn("--synthesized-landing-page-topics-style", cmd)
+        style_idx = cmd.index("--synthesized-landing-page-topics-style") + 1
+        self.assertEqual(cmd[style_idx], "list")
+
+    def test_landing_page_name_uses_version_verbatim(self):
+        cmd = self._capture_merge_cmd("main")
+        name_idx = cmd.index("--synthesized-landing-page-name") + 1
+        self.assertEqual(cmd[name_idx], "Swift - main")
+
+
 class FinalizeCombinedArchive(unittest.TestCase):
     def test_prior_failures_skip_merge(self):
         succeeded, failed = build_docs._finalize_combined_archive(

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1732,6 +1732,7 @@ class CurateNavigator(unittest.TestCase):
 
 
 class CurateNavigatorDryRun(unittest.TestCase):
+
     def _nav(self):
         return {
             "version": 1,
@@ -1826,6 +1827,105 @@ class ValidateNavigationCLI(unittest.TestCase):
                 ],
             )
             self.assertEqual(validate_navigation_cli.main(argv), 1)
+
+
+def _write_landing_page(archive, sections):
+    """Write a minimal synthesized landing page (data/documentation.json).
+
+    `sections` is a list of (title, [identifiers]).
+    """
+    data = archive / "data"
+    data.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "identifier": {"url": "doc://X/documentation", "interfaceLanguage": "swift"},
+        "kind": "symbol",
+        "topicSections": [
+            {"title": t, "identifiers": list(ids)} for t, ids in sections
+        ],
+        "references": {},
+    }
+    (data / "documentation.json").write_text(json.dumps(doc, indent=2) + "\n")
+
+
+def _landing_sections(archive):
+    doc = json.loads((archive / "data" / "documentation.json").read_text())
+    return [(s.get("title"), s.get("identifiers")) for s in doc.get("topicSections", [])]
+
+
+class CurateLandingPage(unittest.TestCase):
+    def _nav(self):
+        return {
+            "version": 1,
+            "groups": [{"title": "Language", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+                {"source": "a", "path": "/documentation/testing"},
+            ]}],
+            "hidden": [{"source": "a", "path": "/documentation/internal"}],
+        }
+
+    def _index_children(self):
+        return [
+            _module("Swift", "/documentation/swift"),
+            _module("Internal", "/documentation/internal"),
+            _module("Testing", "/documentation/testing"),
+        ]
+
+    def test_hidden_modules_removed_from_landing_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            _write_landing_page(archive, [
+                ("Modules", [
+                    "doc://Test/documentation/Swift",
+                    "doc://Test/documentation/Internal",  # hidden, mixed case
+                    "doc://Test/documentation/Testing",
+                ]),
+                ("Tutorials", ["doc://Test/tutorials/getting-started"]),
+            ])
+            curate_navigator.curate_navigator(archive, self._nav())
+            sections = dict(_landing_sections(archive))
+
+        self.assertEqual(sections["Modules"], [
+            "doc://Test/documentation/Swift",
+            "doc://Test/documentation/Testing",
+        ])
+        # Non-hidden sections are untouched.
+        self.assertEqual(sections["Tutorials"], ["doc://Test/tutorials/getting-started"])
+
+    def test_section_emptied_by_hiding_is_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            _write_landing_page(archive, [
+                ("Modules", ["doc://Test/documentation/Swift",
+                             "doc://Test/documentation/Testing"]),
+                ("Internal Stuff", ["doc://Test/documentation/Internal"]),
+            ])
+            curate_navigator.curate_navigator(archive, self._nav())
+            titles = [t for t, _ in _landing_sections(archive)]
+
+        self.assertEqual(titles, ["Modules"])
+
+    def test_missing_landing_page_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            # No data/documentation.json written.
+            curate_navigator.curate_navigator(archive, self._nav())
+            # Index still curated; no error raised.
+            self.assertEqual(_children_of(archive)[0]["type"], "groupMarker")
+
+    def test_landing_page_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), self._index_children())
+            _write_landing_page(archive, [
+                ("Modules", ["doc://Test/documentation/Swift",
+                             "doc://Test/documentation/Internal",
+                             "doc://Test/documentation/Testing"]),
+            ])
+            page = archive / "data" / "documentation.json"
+            curate_navigator.curate_navigator(archive, self._nav())
+            once = page.read_bytes()
+            curate_navigator.curate_navigator(archive, self._nav())
+            twice = page.read_bytes()
+        self.assertEqual(once, twice)
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1248,5 +1248,60 @@ class CleanPackageBuildDirs(unittest.TestCase):
             self.assertEqual(removed, [])
 
 
+class AssembleInSourceOrder(unittest.TestCase):
+    """assemble_in_source_order flattens build results into sources.json order."""
+
+    def test_orders_by_source_index_not_build_order(self):
+        # Built in build order (archive index 1 first), but expect source order.
+        results_by_index = {
+            1: (["archive-1.doccarchive"], {"id": "stdlib"}),
+            0: (["archive-0.doccarchive"], {"id": "book"}),
+        }
+        archives, entries = build_docs.assemble_in_source_order(
+            results_by_index, num_sources=2
+        )
+        self.assertEqual(archives, ["archive-0.doccarchive", "archive-1.doccarchive"])
+        self.assertEqual(entries, [{"id": "book"}, {"id": "stdlib"}])
+
+    def test_multi_target_archives_stay_grouped_and_ordered(self):
+        results_by_index = {
+            0: (["a.doccarchive"], {"id": "book"}),
+            1: (
+                ["spm-A.doccarchive", "spm-B.doccarchive", "spm-C.doccarchive"],
+                {"id": "swiftpm"},
+            ),
+        }
+        archives, entries = build_docs.assemble_in_source_order(
+            results_by_index, num_sources=2
+        )
+        self.assertEqual(
+            archives,
+            [
+                "a.doccarchive",
+                "spm-A.doccarchive",
+                "spm-B.doccarchive",
+                "spm-C.doccarchive",
+            ],
+        )
+        self.assertEqual(entries, [{"id": "book"}, {"id": "swiftpm"}])
+
+    def test_skips_missing_indices(self):
+        # Source at index 1 failed to build and has no result entry.
+        results_by_index = {
+            0: (["a.doccarchive"], {"id": "book"}),
+            2: (["c.doccarchive"], {"id": "testing"}),
+        }
+        archives, entries = build_docs.assemble_in_source_order(
+            results_by_index, num_sources=3
+        )
+        self.assertEqual(archives, ["a.doccarchive", "c.doccarchive"])
+        self.assertEqual(entries, [{"id": "book"}, {"id": "testing"}])
+
+    def test_empty_results(self):
+        archives, entries = build_docs.assemble_in_source_order({}, num_sources=3)
+        self.assertEqual(archives, [])
+        self.assertEqual(entries, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -30,6 +30,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import build_docs  # noqa: E402
+import curate_navigator  # noqa: E402
 import strip_availability  # noqa: E402
 
 
@@ -1059,6 +1060,10 @@ class MergeArchives(unittest.TestCase):
         self.assertIn("--synthesized-landing-page-topics-style", cmd)
         style_idx = cmd.index("--synthesized-landing-page-topics-style") + 1
         self.assertEqual(cmd[style_idx], "list")
+
+        self.assertIn("--synthesized-landing-page-kind", cmd)
+        kind_idx = cmd.index("--synthesized-landing-page-kind") + 1
+        self.assertEqual(cmd[kind_idx], "Project")
 
     def test_landing_page_name_uses_version_verbatim(self):
         cmd = self._capture_merge_cmd("main")

--- a/scripts/validate_navigation.py
+++ b/scripts/validate_navigation.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+"""Standalone checker for navigation.json — run while editing the manifest.
+
+Validates navigation.json against sources.json (mismatches + completeness) and,
+when a merged combined archive is available, dry-runs the curation to report
+dangling/unlisted modules and preview the resulting sidebar — all without
+modifying any build output.
+
+    python3 scripts/validate_navigation.py                 # static checks only
+    python3 scripts/validate_navigation.py --archive PATH  # also check coverage
+
+See ``hacking-index-json.md`` for the underlying mechanics.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import curate_navigator
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--navigation", default=str(SCRIPT_DIR / "navigation.json"),
+        help="path to navigation.json (default: alongside this script)",
+    )
+    parser.add_argument(
+        "--sources", default=str(SCRIPT_DIR / "sources.json"),
+        help="path to sources.json (default: alongside this script)",
+    )
+    parser.add_argument(
+        "--archive", default=None,
+        help="merged .doccarchive to check coverage against and preview "
+             "(default: auto-detect .build-output/<version> if present)",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_json(path):
+    return json.loads(Path(path).read_text())
+
+
+def _auto_archive(sources, sources_path):
+    """Return the conventional combined archive path if it exists, else None.
+
+    Resolved relative to sources.json (…/<dir>/../.build-output/<version>), so
+    pointing --sources at a throwaway file does not pick up the real build.
+    """
+    version = sources.get("version")
+    if not version:
+        return None
+    repo_root = Path(sources_path).resolve().parent.parent
+    candidate = repo_root / ".build-output" / str(version)
+    return candidate if (candidate / "index" / "index.json").is_file() else None
+
+
+def main(argv=None):
+    """Return 0 when navigation.json is valid (and covers the archive), else 1."""
+    args = _parse_args(argv)
+
+    try:
+        navigation = _load_json(args.navigation)
+        sources = _load_json(args.sources)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Error: could not read inputs: {e}")
+        return 1
+
+    # 1. Static checks: mismatches + completeness against sources.json.
+    errors = curate_navigator.validate_navigation(navigation, sources)
+    if errors:
+        print("navigation.json is NOT valid:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print(f"navigation.json is valid against {args.sources} (no mismatches, "
+          "all sources represented).")
+
+    # 2. Optional coverage check + preview against a merged archive.
+    archive = Path(args.archive) if args.archive else _auto_archive(sources, args.sources)
+    if archive is None:
+        print("No merged archive given or found — skipped coverage check. "
+              "Pass --archive to verify against a built combined archive.")
+        return 0
+
+    print(f"\nChecking coverage against {archive} ...")
+    try:
+        preview = curate_navigator.dry_run(archive, navigation)
+    except curate_navigator.NavigationError as e:
+        print(f"  COVERAGE ERROR: {e}")
+        return 1
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"  Error reading archive index: {e}")
+        return 1
+
+    for lang, children in preview.items():
+        print(f"\nSidebar preview [{lang}]:")
+        for node in children:
+            kind = node.get("type", "?")
+            marker = "  " if kind == "groupMarker" else "    - "
+            print(f"{marker}{node.get('title')}")
+    print("\nCoverage OK — every module is grouped or hidden.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Change synthesized page layout:
 -  `--synthesized-landing-page-topics-style list`
 - `kind` as `Project`
- name derived from version in Sources.json
- implemented workaround for https://github.com/swiftlang/swift-docc/issues/1532 to not drop the custom HTML header/footer when adjusting the hosting base path
- hard-code hacked the index.json data structure to introduce some hierarchy, and reflected the same hierarchy into the top-level synthesized page, making the icon+title setup consistent across the collections.

sample effect:

<img width="1467" height="1101" alt="Screenshot 2026-06-01 at 5 31 23 PM" src="https://github.com/user-attachments/assets/27bb91b4-554e-4dae-8a1f-67849b35fb6e" />
