### PR TITLE
nightly builds of docs 

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build-docs:
     name: Build combined documentation
+    if: github.event_name != 'schedule' || github.repository == 'swiftlang/docs'
     runs-on: ubuntu-latest
     container:
       # image: swiftlang/swift:nightly-main-jammy

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches: [main]
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Updating GH workflow to run a scheduled nightly build of the latest docs from sources, and enable manual invocation through GH (if user has appropriate permissions) if needed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
