### PR TITLE
adding options to generate markdown into the combined docs

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -46,6 +46,12 @@ DOCC_BUILD_FLAGS = [
     "--experimental-enable-custom-templates",
     "--enable-mentioned-in",
     "--enable-experimental-external-link-support",
+    # Emit a markdown copy of every rendered document (plus a manifest) under
+    # data/documentation/. These sidecar files survive docc merge and
+    # process-archive transform-for-static-hosting, so they reach the published
+    # combined archive for consumption by crawlers and other tooling.
+    "--enable-experimental-markdown-output",
+    "--enable-experimental-markdown-output-manifest",
 ]
 
 # Common template files to copy into each .docc catalog before building


### PR DESCRIPTION
## Summary

Adds docc build options (experimental in 6.3) to add markdown generation into the DocC archives.

This would have included HTML as well, but in practice I found the processing we do for the combined docs (invoking `docc process-archive`) has an unfortunate side effect of stripping out the additional HTML expansions that can be added in the experimental static content with extras stuff (see https://github.com/swiftlang/swift-docc/issues/1588)

Also note that this *does not* get us to LLMS.txt kind of additions for the DocC content here - there's [a notable gap](https://github.com/swiftlang/swift-docc/issues/1589) between the markdown generation that was enabled within a DocC archive and what that convention proposes. Opened an enhancement request to build onto the manifest that *does* get generated to get the content more accessible to crawlers and/or agents.

Either honestly would work, so right now I'm going for whatever *can* work, and putting it in belt and suspenders.


## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
