### PR TITLE
content updates in Embedded Swift for a plain DocC build - not package build

### DIFF
--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -59,7 +59,7 @@
       "type": "git",
       "repo": "https://github.com/swiftlang/swift-embedded-examples.git",
       "ref": "main",
-      "targets": ["EmbeddedSwift"]
+      "docc_catalog": "Sources/EmbeddedSwift/EmbeddedSwift.docc"
     },
     {
       "id": "swift-wasm",


### PR DESCRIPTION


## Summary

Reverts the sources back to a straight DocC build here to get the corrected output in the combined docs

## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
