### PR TITLE
reorganizing left nav based on feedback

### DIFF
--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -5,8 +5,7 @@
       "title": "Swift",
       "modules": [
         { "source": "swift-book", "path": "/documentation/the-swift-programming-language" },
-        { "source": "compiler-diagnostics", "path": "/documentation/diagnostics" },
-        { "source": "swift-migration-guide", "path": "/documentation/migrationguide" }
+        { "source": "compiler-diagnostics", "path": "/documentation/diagnostics" }
        ]
     },
     {
@@ -32,12 +31,7 @@
       "modules": [
         { "source": "embedded-swift", "path": "/documentation/embeddedswift" },
         { "source": "swift-wasm", "path": "/documentation/wasmguide" },
-        { "source": "swift-android", "path": "/documentation/swiftandroid" }
-      ]
-    },
-    {
-      "title": "Server-Side Swift",
-      "modules": [
+        { "source": "swift-android", "path": "/documentation/swiftandroid" },
         { "source": "server-guides", "path": "/documentation/serverguides" },
         { "source": "swift-server-todos-tutorial", "path": "/tutorials/getting-started-swift-server" }
       ]
@@ -46,6 +40,12 @@
       "title": "Interoperability",
       "modules": [
         { "source": "swift-java", "path": "/documentation/swiftjavadocumentation", "title": "Swift and Java" }
+      ]
+    },
+    {
+      "title": "Releases",
+      "modules": [
+        { "source": "swift-migration-guide", "path": "/documentation/migrationguide" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Re-organizes the left-nav groupings
- makes a "releases" section and moves the migration guide beneath it
- moves the Swift Server content into Platforms


## Validation

Here's what this looks like rendered locally:

```bash
./scripts/build_docs.py
python3 -m http.server 8123 --directory .build-output
```

<img width="1248" height="1314" alt="Screenshot 2026-07-22 at 12 38 43 PM" src="https://github.com/user-attachments/assets/26490be4-f4ce-4c34-be91-deb2e92401dc" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
