### PR TITLE
renaming libraries collection - left nav tweaks only

### DIFF
--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -10,9 +10,9 @@
        ]
     },
     {
-      "title": "Essential Libraries",
+      "title": "Libraries",
       "modules": [
-        { "source": "swift-stdlib", "path": "/documentation/swift" },
+        { "source": "swift-stdlib", "path": "/documentation/swift", "title": "Standard Library" },
         { "source": "swift-testing", "path": "/documentation/testing" }
       ]
     },


### PR DESCRIPTION
## Summary

- Renames "Essential Libraries" to "Libraries"
- for the left nav element, changes "Swift" to "Standard Library" (doesn't address curation within that collection though)

## Validation

<img width="1144" height="1106" alt="Screenshot 2026-07-22 at 4 21 07 PM" src="https://github.com/user-attachments/assets/a5d1e9e6-c91e-4edf-8a5b-eebc94208d99" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
