### PR TITLE
renaming left nav elements

### DIFF
--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -19,12 +19,12 @@
     {
       "title": "Tools",
       "modules": [
-        { "source": "docc-documentation", "path": "/documentation/docc" },
-        { "source": "swiftpm", "path": "/documentation/packagemanagerdocs", "title": "Swift Package Manager" },
+        { "source": "docc-documentation", "path": "/documentation/docc", "title": "Documentation (DocC)" },
+        { "source": "swiftpm", "path": "/documentation/packagemanagerdocs", "title": "Package Manager (SwiftPM)" },
         { "source": "swiftpm", "path": "/documentation/packagedescription" },
         { "source": "swiftpm", "path": "/documentation/packageplugin" },
-        { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "Swift extension for VS Code" },
-        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Swiftly" }
+        { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "IDE Integration" },
+        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Installer (Swiftly)" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

Renames left nav elements:

- swiftly -> Installer (Swiftly)
- Swift Package Manager -> Package Manager (SwiftPM)
- Swift extension for VS Code -> IDE Integration
- DocC -> Documentation (DocC)

## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
