### PR TITLE
adding an Apple Platforms collection

### DIFF
--- a/apple-platforms/Package.swift
+++ b/apple-platforms/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftApplePlatforms",
+  products: [
+    .library(name: "SwiftApplePlatforms", targets: ["SwiftApplePlatforms"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
+  ],
+  targets: [
+    .target(
+      name: "SwiftApplePlatforms",
+      path: "Sources"
+    )
+  ]
+)

--- a/apple-platforms/Sources/SwiftApplePlatforms.docc/Documentation.md
+++ b/apple-platforms/Sources/SwiftApplePlatforms.docc/Documentation.md
@@ -1,0 +1,15 @@
+# ``SwiftApplePlatforms``
+
+Build and ship apps for iOS, iPadOS, macOS, watchOS, tvOS, and visionOS.
+
+@Metadata {
+    @DisplayName("Apple platforms")
+    @TitleHeading("")
+}
+
+Swift is the primary language for building apps across Apple's platforms, with
+deep integration into Xcode, Apple's SDKs, and frameworks like SwiftUI and
+UIKit.
+
+Visit [Apple Developer Documentation](https://developer.apple.com/documentation/technologies)
+for platform-specific APIs, frameworks, and guides.

--- a/apple-platforms/Sources/_empty.swift
+++ b/apple-platforms/Sources/_empty.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -31,6 +31,7 @@
       "title": "Platforms",
       "modules": [
         { "source": "swift-android", "path": "/documentation/swiftandroid", "title": "Android" },
+        { "source": "swift-apple-platforms", "path": "/documentation/swiftappleplatforms", "title": "Apple platforms" },
         { "source": "embedded-swift", "path": "/documentation/embeddedswift", "title": "Embedded Swift" },
         { "source": "swift-linux", "path": "/documentation/swiftlinux", "title": "Linux" },
         { "source": "swift-wasm", "path": "/documentation/wasmguide", "title": "WebAssembly (Wasm)"}

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -91,6 +91,12 @@
       "targets": ["SwiftAndroid"]
     },
     {
+      "id": "swift-apple-platforms",
+      "type": "local",
+      "path": "apple-platforms",
+      "targets": ["SwiftApplePlatforms"]
+    },
+    {
       "id": "swift-server-todos-tutorial",
       "type": "git",
       "repo": "https://github.com/swiftlang/swift-server-todos-tutorial.git",


### PR DESCRIPTION
## Summary

adds "Apple platforms" to the collection list of platforms in the central doc catalog with a placeholder page that directs off to developer.apple.com per feedback request


## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
