### PR TITLE
adding a Windows platform collection

### DIFF
--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -33,7 +33,8 @@
         { "source": "swift-android", "path": "/documentation/swiftandroid", "title": "Android" },
         { "source": "embedded-swift", "path": "/documentation/embeddedswift", "title": "Embedded Swift" },
         { "source": "swift-linux", "path": "/documentation/swiftlinux", "title": "Linux" },
-        { "source": "swift-wasm", "path": "/documentation/wasmguide", "title": "WebAssembly (Wasm)"}
+        { "source": "swift-wasm", "path": "/documentation/wasmguide", "title": "WebAssembly (Wasm)"},
+        { "source": "swift-windows", "path": "/documentation/swiftwindows", "title": "Windows" }
       ]
     },
     {

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -78,6 +78,12 @@
       "targets": ["SwiftLinux"]
     },
     {
+      "id": "swift-windows",
+      "type": "local",
+      "path": "windows",
+      "targets": ["SwiftWindows"]
+    },
+    {
       "id": "official-libraries",
       "type": "local",
       "path": "libraries",

--- a/windows/Package.swift
+++ b/windows/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftWindows",
+  products: [
+    .library(name: "SwiftWindows", targets: ["SwiftWindows"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
+  ],
+  targets: [
+    .target(
+      name: "SwiftWindows",
+      path: "Sources"
+    )
+  ]
+)

--- a/windows/Sources/SwiftWindows.docc/Documentation.md
+++ b/windows/Sources/SwiftWindows.docc/Documentation.md
@@ -1,0 +1,15 @@
+# ``SwiftWindows``
+
+Build and run Swift on Windows.
+
+@Metadata {
+    @DisplayName("Windows")
+    @TitleHeading("")
+}
+
+Swift supports native development on Windows, including a downloadable
+toolchain and integration with Visual Studio's build tools.
+
+Visit [Install Swift on Windows](https://www.swift.org/install/windows/) to
+get started. More guidance on building and porting packages to Windows is
+coming soon.

--- a/windows/Sources/_empty.swift
+++ b/windows/Sources/_empty.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//


### PR DESCRIPTION

## Summary

Adds a short placeholder landing page for the Windows platform, pointing to swift.org's install instructions, with room to grow once building/porting guidance for Windows is vetted.


## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
