### PR TITLE
side nav links

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,7 +38,7 @@ links to content outside the archive, with no backing `sources.json` id. Give
 these a `title` and an `https://` `url` instead of `source`/`path`:
 
 ```jsonc
-{ "title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/" }
+{ "title": "Swift and C++", "url": "https://www.swift.org/documentation/cxx-interop/" }
 ```
 
 External entries render in the sidebar only — they get no card on the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,19 @@ in the merged index must be either placed in a group or listed under `hidden` �
 `navigator-curation` build step), and fails the build on any mismatch or
 uncovered module. See `../hacking-index-json.md` for the underlying mechanics.
 
+A group's `modules` list may also contain **external-link entries** — plain
+links to content outside the archive, with no backing `sources.json` id. Give
+these a `title` and an `https://` `url` instead of `source`/`path`:
+
+```jsonc
+{ "title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/" }
+```
+
+External entries render in the sidebar only — they get no card on the
+synthesized landing page — and aren't valid under `hidden` (there's no module
+to hide). An optional `type` overrides the sidebar icon; it defaults to
+`"resources"`.
+
 ### Checking the manifest while editing
 
 Run the standalone checker — it does **not** modify any build output:

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -42,6 +42,15 @@ def _entries(navigation):
         yield entry, "hidden"
 
 
+def _is_external_entry(entry):
+    """An external-link entry has a `url` instead of a `source`/`path`.
+
+    It has no backing module in the merged index — the sidebar node is
+    synthesized directly from the manifest entry.
+    """
+    return "url" in entry
+
+
 def validate_navigation(navigation, sources_config):
     """Validate navigation.json against itself and sources.json (offline).
 
@@ -71,14 +80,40 @@ def validate_navigation(navigation, sources_config):
             errors.append(f"navigation.json: group '{group.get('title')}' "
                           "'modules' must be a list")
 
-    # Per-entry shape, duplicate paths, and source linkage.
+    # Per-entry shape, duplicate paths/urls, and source linkage.
     source_ids = {s.get("id") for s in sources_config.get("sources", [])}
     referenced_sources = set()
-    seen_paths = set()
+    seen_identifiers = set()
     for entry, where in _entries(navigation):
         if not isinstance(entry, dict):
             errors.append(f"navigation.json: a {where} entry must be an object")
             continue
+
+        if _is_external_entry(entry):
+            title = entry.get("title")
+            url = entry.get("url")
+            if not title:
+                errors.append(f"navigation.json: an external {where} entry is missing 'title'")
+            if not url:
+                errors.append(f"navigation.json: an external {where} entry is missing 'url'")
+            elif not url.startswith("https://"):
+                errors.append(
+                    f"navigation.json: external entry '{title or url}' has a 'url' "
+                    f"that is not https:// ({url!r})"
+                )
+            if where == "hidden":
+                errors.append(
+                    f"navigation.json: external entry '{title or url}' is not valid "
+                    "under 'hidden' (there is no module to hide)"
+                )
+            if url:
+                if ("url", url) in seen_identifiers:
+                    errors.append(
+                        f"navigation.json: url '{url}' appears more than once"
+                    )
+                seen_identifiers.add(("url", url))
+            continue
+
         src = entry.get("source")
         path = entry.get("path")
         if not src:
@@ -93,11 +128,11 @@ def validate_navigation(navigation, sources_config):
                     "not present in sources.json"
                 )
         if path:
-            if path in seen_paths:
+            if ("path", path) in seen_identifiers:
                 errors.append(
                     f"navigation.json: path '{path}' appears more than once"
                 )
-            seen_paths.add(path)
+            seen_identifiers.add(("path", path))
 
     # Completeness: every source must be represented (placed or hidden).
     for sid in sorted(s for s in source_ids if s):
@@ -111,17 +146,28 @@ def validate_navigation(navigation, sources_config):
 
 
 def _group_paths(navigation):
-    """Paths that must be rendered (and therefore must exist in the index)."""
+    """Paths that must be rendered (and therefore must exist in the index).
+
+    Excludes external-link entries — they have no backing index module.
+    """
     return {
         entry["path"]
         for group in navigation.get("groups", [])
         for entry in group.get("modules", [])
+        if not _is_external_entry(entry)
     }
 
 
 def _manifest_paths(navigation):
-    """All paths the manifest accounts for (grouped + hidden)."""
-    return {entry["path"] for entry, _ in _entries(navigation)}
+    """All paths the manifest accounts for (grouped + hidden).
+
+    Excludes external-link entries — they have no backing index module.
+    """
+    return {
+        entry["path"]
+        for entry, _ in _entries(navigation)
+        if not _is_external_entry(entry)
+    }
 
 
 def _curate_children(children, navigation):
@@ -165,6 +211,14 @@ def _curate_children(children, navigation):
     for group in navigation.get("groups", []):
         new_children.append({"type": "groupMarker", "title": group["title"]})
         for entry in group.get("modules", []):
+            if _is_external_entry(entry):
+                new_children.append({
+                    "type": entry.get("type", "resources"),
+                    "title": entry["title"],
+                    "path": entry["url"],
+                    "external": True,
+                })
+                continue
             node = path_map[entry["path"]]
             if entry.get("title"):
                 node["title"] = entry["title"]
@@ -260,6 +314,8 @@ def _curate_landing_page(archive_path, navigation):
     for group in navigation.get("groups", []):
         group_idents = []
         for entry in group.get("modules", []):
+            if _is_external_entry(entry):
+                continue
             ident = page_by_path.get(entry["path"].lower())
             if ident is not None:
                 group_idents.append(ident)

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -33,6 +33,21 @@ class NavigationError(Exception):
     """Raised when curation cannot be applied (dangling/unlisted modules, etc.)."""
 
 
+# `RenderIndex.Node.type` enum, from `hacking-index-json.md` (mirrors
+# `RenderIndex.spec.json`), minus `groupMarker`: that type forces
+# docc-render's `NavigatorCardItem.vue` to null out the node's `path`
+# (`:url="isGroupMarker ? null : (item.path || '')"`), which would silently
+# turn an external-link entry into a dead, non-clickable label.
+VALID_EXTERNAL_LINK_TYPES = frozenset({
+    "article", "associatedtype", "buildSetting", "case", "collection", "class",
+    "container", "dictionarySymbol", "enum", "extension", "func", "httpRequest",
+    "init", "languageGroup", "learn", "macro", "method", "module", "op",
+    "overview", "project", "property", "propertyListKey",
+    "propertyListKeyReference", "protocol", "resources", "root", "sampleCode",
+    "section", "struct", "subscript", "symbol", "typealias", "union", "var",
+})
+
+
 def _entries(navigation):
     """Yield every (entry, where) across groups and hidden, for validation."""
     for group in navigation.get("groups", []):
@@ -49,6 +64,88 @@ def _is_external_entry(entry):
     synthesized directly from the manifest entry.
     """
     return "url" in entry
+
+
+def _is_synthesized_external_node(node):
+    """A previously-synthesized external-link node from an earlier curation
+    pass, identified the same way docc-render tells it apart from an
+    internal page: its `path` is an absolute URL, not an archive-relative
+    path. Distinct from `RenderIndex.Node.isExternal` (`"external"` in the
+    JSON), which real `docc merge` output never sets for nodes produced by
+    this single-archive merge pipeline, but which this check does not rely
+    on either way.
+    """
+    path = node.get("path")
+    return isinstance(path, str) and (path.startswith("http://") or path.startswith("https://"))
+
+
+def _is_hybrid_entry(entry):
+    """True if an external-link entry (has `url`) also carries `source`/
+    `path` — invalid, since an entry can't be both a module pointer and an
+    external link.
+    """
+    return "source" in entry or "path" in entry
+
+
+def _entry_label(entry):
+    """Human-readable name for an entry in error messages: its `title` if
+    it's a non-empty string, else its raw `url`."""
+    title = entry.get("title")
+    return title if isinstance(title, str) and title else entry.get("url")
+
+
+def _external_entry_shape_errors(entry, where):
+    """Structural validation of an external-link entry, independent of
+    sources.json.
+
+    Shared by ``validate_navigation()`` and, defensively, by curation
+    itself: ``curate_navigator()``/``dry_run()`` take no sources.json and
+    can't call ``validate_navigation()`` on their own, so they call this
+    directly before trusting an entry's `title`/`url`/`type`.
+    """
+    if _is_hybrid_entry(entry):
+        return [
+            f"navigation.json: a {where} entry has both 'url' and "
+            "'source'/'path' — an entry must be either a module "
+            "pointer or an external link, not both"
+        ]
+
+    errors = []
+    title = entry.get("title")
+    url = entry.get("url")
+    label = _entry_label(entry)
+
+    if not isinstance(title, str) or not title:
+        errors.append(f"navigation.json: an external {where} entry is missing a non-empty 'title'")
+
+    if not isinstance(url, str) or not url:
+        errors.append(f"navigation.json: an external {where} entry is missing a non-empty 'url'")
+    elif url != url.strip():
+        errors.append(
+            f"navigation.json: external entry '{label}' has a 'url' "
+            f"with leading/trailing whitespace ({url!r})"
+        )
+    elif not url.startswith("https://"):
+        errors.append(
+            f"navigation.json: external entry '{label}' has a 'url' "
+            f"that is not https:// ({url!r})"
+        )
+    elif not urlparse(url).netloc:
+        errors.append(
+            f"navigation.json: external entry '{label}' has a 'url' "
+            f"with no host ({url!r})"
+        )
+
+    entry_type = entry.get("type")
+    if entry_type is not None and (
+        not isinstance(entry_type, str) or entry_type not in VALID_EXTERNAL_LINK_TYPES
+    ):
+        errors.append(
+            f"navigation.json: external entry '{label}' has an "
+            f"invalid 'type' ({entry_type!r})"
+        )
+
+    return errors
 
 
 def validate_navigation(navigation, sources_config):
@@ -90,23 +187,21 @@ def validate_navigation(navigation, sources_config):
             continue
 
         if _is_external_entry(entry):
-            title = entry.get("title")
+            errors.extend(_external_entry_shape_errors(entry, where))
+            if _is_hybrid_entry(entry):
+                continue
+
             url = entry.get("url")
-            if not title:
-                errors.append(f"navigation.json: an external {where} entry is missing 'title'")
-            if not url:
-                errors.append(f"navigation.json: an external {where} entry is missing 'url'")
-            elif not url.startswith("https://"):
-                errors.append(
-                    f"navigation.json: external entry '{title or url}' has a 'url' "
-                    f"that is not https:// ({url!r})"
-                )
+            label = _entry_label(entry)
+
             if where == "hidden":
                 errors.append(
-                    f"navigation.json: external entry '{title or url}' is not valid "
+                    f"navigation.json: external entry '{label}' is not valid "
                     "under 'hidden' (there is no module to hide)"
                 )
-            if url:
+                continue
+
+            if isinstance(url, str) and url:
                 if ("url", url) in seen_identifiers:
                     errors.append(
                         f"navigation.json: url '{url}' appears more than once"
@@ -176,9 +271,13 @@ def _curate_children(children, navigation):
     Raises NavigationError on dangling grouped paths, on index modules the
     manifest neither groups nor hides, or on unexpected pathless nodes.
     """
-    # Drop any existing group markers so re-running is idempotent, then index
-    # the remaining nodes by path.
-    real_nodes = [c for c in children if c.get("type") != "groupMarker"]
+    # Drop any existing group markers and previously-synthesized external
+    # links so re-running is idempotent, then index the remaining real
+    # modules by path.
+    real_nodes = [
+        c for c in children
+        if c.get("type") != "groupMarker" and not _is_synthesized_external_node(c)
+    ]
     path_map = {}
     for node in real_nodes:
         path = node.get("path")
@@ -212,6 +311,12 @@ def _curate_children(children, navigation):
         new_children.append({"type": "groupMarker", "title": group["title"]})
         for entry in group.get("modules", []):
             if _is_external_entry(entry):
+                shape_errors = _external_entry_shape_errors(entry, "group")
+                if shape_errors:
+                    raise NavigationError(
+                        "navigation.json has an invalid external-link entry: "
+                        + "; ".join(shape_errors)
+                    )
                 new_children.append({
                     "type": entry.get("type", "resources"),
                     "title": entry["title"],

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -68,15 +68,13 @@ def _is_external_entry(entry):
 
 def _is_synthesized_external_node(node):
     """A previously-synthesized external-link node from an earlier curation
-    pass, identified the same way docc-render tells it apart from an
-    internal page: its `path` is an absolute URL, not an archive-relative
-    path. Distinct from `RenderIndex.Node.isExternal` (`"external"` in the
-    JSON), which real `docc merge` output never sets for nodes produced by
-    this single-archive merge pipeline, but which this check does not rely
-    on either way.
+    pass, so re-curating an already-curated archive doesn't mistake it for
+    a real merged module. Identified by the same `external` marker
+    `_curate_children` stamps on it when synthesizing it — real `docc
+    merge` output never sets this for nodes produced by this
+    single-archive merge pipeline.
     """
-    path = node.get("path")
-    return isinstance(path, str) and (path.startswith("http://") or path.startswith("https://"))
+    return node.get("external") is True
 
 
 def _is_hybrid_entry(entry):
@@ -102,13 +100,16 @@ def _external_entry_shape_errors(entry, where):
     itself: ``curate_navigator()``/``dry_run()`` take no sources.json and
     can't call ``validate_navigation()`` on their own, so they call this
     directly before trusting an entry's `title`/`url`/`type`.
+
+    Returns ``(errors, is_hybrid)`` — callers branch on ``is_hybrid``
+    without re-deriving it themselves.
     """
     if _is_hybrid_entry(entry):
         return [
             f"navigation.json: a {where} entry has both 'url' and "
             "'source'/'path' — an entry must be either a module "
             "pointer or an external link, not both"
-        ]
+        ], True
 
     errors = []
     title = entry.get("title")
@@ -145,7 +146,7 @@ def _external_entry_shape_errors(entry, where):
             f"invalid 'type' ({entry_type!r})"
         )
 
-    return errors
+    return errors, False
 
 
 def validate_navigation(navigation, sources_config):
@@ -187,17 +188,17 @@ def validate_navigation(navigation, sources_config):
             continue
 
         if _is_external_entry(entry):
-            errors.extend(_external_entry_shape_errors(entry, where))
-            if _is_hybrid_entry(entry):
+            shape_errors, is_hybrid = _external_entry_shape_errors(entry, where)
+            errors.extend(shape_errors)
+            if is_hybrid:
                 continue
 
             url = entry.get("url")
-            label = _entry_label(entry)
 
             if where == "hidden":
                 errors.append(
-                    f"navigation.json: external entry '{label}' is not valid "
-                    "under 'hidden' (there is no module to hide)"
+                    f"navigation.json: external entry '{_entry_label(entry)}' is "
+                    "not valid under 'hidden' (there is no module to hide)"
                 )
                 continue
 
@@ -311,7 +312,7 @@ def _curate_children(children, navigation):
         new_children.append({"type": "groupMarker", "title": group["title"]})
         for entry in group.get("modules", []):
             if _is_external_entry(entry):
-                shape_errors = _external_entry_shape_errors(entry, "group")
+                shape_errors, _ = _external_entry_shape_errors(entry, "group")
                 if shape_errors:
                     raise NavigationError(
                         "navigation.json has an invalid external-link entry: "

--- a/scripts/hacking-index-json.md
+++ b/scripts/hacking-index-json.md
@@ -147,7 +147,7 @@ and no frontend change are required for this to work — the scheme on `path`
 is the whole mechanism:
 
 ```jsonc
-{ "type": "resources", "title": "C++ Interop", "path": "https://www.swift.org/documentation/cxx-interop/", "external": true }
+{ "type": "resources", "title": "Swift and C++", "path": "https://www.swift.org/documentation/cxx-interop/", "external": true }
 ```
 
 The `external` boolean on `RenderIndex.Node` (`RenderIndexJSON/RenderIndex.swift`)

--- a/scripts/hacking-index-json.md
+++ b/scripts/hacking-index-json.md
@@ -77,7 +77,7 @@ Two types matter most for curation:
   `path`, no `children`**. The renderer draws it as a non-clickable section
   heading among its siblings.
 
-## The three curation operations
+## The four curation operations
 
 ### 1. Inject a label (`groupMarker`)
 
@@ -135,6 +135,36 @@ There are **two** ways, with different UX:
   Note: a `groupMarker` with `children` is *not* in the example; the safe,
   proven pattern is **(a) flat markers**. Prefer (a) unless collapsibility is a
   hard requirement and you've confirmed (b) renders.
+
+### 4. Link to external content
+
+A Node's `path` need not be archive-relative — it can be a full URL with a
+scheme (`https://...`). Verified against `swift-docc-render`'s
+`Reference.vue`: its `isInternal` check treats any `url` that doesn't start
+with `/` or `#` as external and renders it via `ReferenceExternal.vue` (a
+plain `<a href>`) instead of a `router-link`. No `type`, no `external` flag,
+and no frontend change are required for this to work — the scheme on `path`
+is the whole mechanism:
+
+```jsonc
+{ "type": "resources", "title": "C++ Interop", "path": "https://www.swift.org/documentation/cxx-interop/", "external": true }
+```
+
+The `external` boolean on `RenderIndex.Node` (`RenderIndexJSON/RenderIndex.swift`)
+is a distinct, narrower concept — DocC only sets it `true` for nodes indexed
+from *another already-built DocC archive* resolved via cross-archive link
+resolution (`NavigatorIndex.swift`'s `index(renderNode: ExternalRenderNode...)`).
+As of this writing, no rendering logic in `swift-docc-render`'s `Navigator`
+component tree actually branches on it — setting it on a hand-authored
+external-link node is harmless/future-proofing, not load-bearing.
+
+`scripts/curate_navigator.py`'s manifest (`navigation.json`) supports
+authoring this kind of node directly, without a backing module: a group's
+`modules[]` array may contain an entry with `title` + `url` (instead of
+`source` + `path`), and curation synthesizes the node above from it. See
+`scripts/README.md`'s "Navigation manifest" section for the exact shape. Such
+entries are sidebar-only — they get no landing-page card — since there is no
+merged-archive identifier to attach one to.
 
 ## Where this slots into the combined build
 

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -48,7 +48,7 @@
       "title": "Interoperability",
       "modules": [
         { "source": "swift-java", "path": "/documentation/swiftjavadocumentation", "title": "Swift and Java" },
-        { "title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/" }
+        { "title": "Swift and C++", "url": "https://www.swift.org/documentation/cxx-interop/" }
       ]
     },
     {

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -47,7 +47,8 @@
     {
       "title": "Interoperability",
       "modules": [
-        { "source": "swift-java", "path": "/documentation/swiftjavadocumentation", "title": "Swift and Java" }
+        { "source": "swift-java", "path": "/documentation/swiftjavadocumentation", "title": "Swift and Java" },
+        { "title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/" }
       ]
     },
     {

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1382,6 +1382,57 @@ class ValidateNavigation(unittest.TestCase):
         errors = curate_navigator.validate_navigation(nav, self.SOURCES)
         self.assertTrue(errors)
 
+    def test_valid_external_entry_has_no_errors(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]},
+        ])
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
+    def test_external_entry_missing_url_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [{"title": "C++ Interop"}]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(errors)
+
+    def test_external_entry_missing_title_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(errors)
+
+    def test_external_entry_non_https_url_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "http://www.swift.org/documentation/cxx-interop/"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("https://" in e for e in errors), errors)
+
+    def test_external_entry_under_hidden_is_reported(self):
+        nav = self._nav(hidden=[
+            {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/"},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("hidden" in e for e in errors), errors)
+
+    def test_duplicate_external_urls_are_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/"},
+                {"title": "C++ Interop Again", "url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("cxx-interop" in e for e in errors), errors)
+
 
 class CurateNavigator(unittest.TestCase):
     def _nav(self):
@@ -1494,6 +1545,59 @@ class CurateNavigator(unittest.TestCase):
             archive.mkdir()
             with self.assertRaises(curate_navigator.NavigationError):
                 curate_navigator.curate_navigator(archive, self._nav())
+
+    def test_external_entry_is_synthesized(self):
+        nav = {
+            "version": 1,
+            "groups": [{"title": "Interoperability", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]}],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [_module("Swift", "/documentation/swift")])
+            curate_navigator.curate_navigator(archive, nav)
+            kids = _children_of(archive)
+
+        self.assertEqual(len(kids), 3)
+        external = kids[2]
+        self.assertEqual(external["title"], "C++ Interop")
+        self.assertEqual(external["path"], "https://www.swift.org/documentation/cxx-interop/")
+        self.assertEqual(external["type"], "resources")
+        self.assertTrue(external["external"])
+        self.assertNotIn("children", external)
+
+    def test_external_entry_honors_explicit_type(self):
+        nav = {
+            "version": 1,
+            "groups": [{"title": "Interoperability", "modules": [
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/",
+                 "type": "article"},
+            ]}],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [])
+            curate_navigator.curate_navigator(archive, nav)
+            kids = _children_of(archive)
+
+        self.assertEqual(kids[1]["type"], "article")
+
+    def test_external_entry_does_not_affect_dangling_or_unlisted_checks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [_module("Swift", "/documentation/swift")])
+            nav = {
+                "version": 1,
+                "groups": [{"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                    {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/"},
+                ]}],
+                "hidden": [],
+            }
+            # Should not raise: the external entry has no path to be dangling
+            # or unlisted against the merged index.
+            curate_navigator.curate_navigator(archive, nav)
 
     def test_malformed_index_raises(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1780,6 +1884,28 @@ class CurateLandingPage(unittest.TestCase):
             titles = [t for t, _ in _landing_sections(archive)]
 
         self.assertEqual(titles, ["Language"])
+
+    def test_external_entry_produces_no_landing_page_card(self):
+        nav = {
+            "version": 1,
+            "groups": [
+                {"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/swift"},
+                    {"title": "C++ Interop",
+                     "url": "https://www.swift.org/documentation/cxx-interop/"},
+                ]},
+            ],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [_module("Swift", "/documentation/swift")])
+            _write_landing_page(archive, [
+                ("Modules", ["doc://Test/documentation/Swift"]),
+            ])
+            curate_navigator.curate_navigator(archive, nav)
+            sections = _landing_sections(archive)
+
+        self.assertEqual(sections, [("Language", ["doc://Test/documentation/Swift"])])
 
     def test_overwrites_kept_reference_kind_and_role(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1392,11 +1392,14 @@ class ValidateNavigation(unittest.TestCase):
         self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
 
     def test_external_entry_missing_url_is_reported(self):
+        # `url` key present but empty — still classified as external (has a
+        # `url` key at all), unlike an entry that omits `url` entirely (which
+        # would misclassify as a plain module pointer missing source/path).
         nav = self._nav(groups=[
-            {"title": "Lang", "modules": [{"title": "C++ Interop"}]},
+            {"title": "Lang", "modules": [{"title": "C++ Interop", "url": ""}]},
         ])
         errors = curate_navigator.validate_navigation(nav, self.SOURCES)
-        self.assertTrue(errors)
+        self.assertTrue(any("non-empty 'url'" in e for e in errors), errors)
 
     def test_external_entry_missing_title_is_reported(self):
         nav = self._nav(groups=[
@@ -1405,7 +1408,7 @@ class ValidateNavigation(unittest.TestCase):
             ]},
         ])
         errors = curate_navigator.validate_navigation(nav, self.SOURCES)
-        self.assertTrue(errors)
+        self.assertTrue(any("non-empty 'title'" in e for e in errors), errors)
 
     def test_external_entry_non_https_url_is_reported(self):
         nav = self._nav(groups=[
@@ -1432,6 +1435,112 @@ class ValidateNavigation(unittest.TestCase):
         ])
         errors = curate_navigator.validate_navigation(nav, self.SOURCES)
         self.assertTrue(any("cxx-interop" in e for e in errors), errors)
+
+    def test_non_string_url_is_reported_not_crashed(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [{"title": "C++ Interop", "url": 12345}]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("non-empty 'url'" in e for e in errors), errors)
+
+    def test_non_string_title_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": 12345, "url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("non-empty 'title'" in e for e in errors), errors)
+
+    def test_hybrid_entry_with_source_and_url_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift", "title": "X",
+                 "url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("both" in e for e in errors), errors)
+
+    def test_hybrid_entry_does_not_validate_its_bogus_source(self):
+        # The hybrid-entry error alone should surface; a typo'd source on the
+        # same entry must not silently slip past unreported OR get evaluated
+        # as if it were a normal module pointer.
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "TYPO_BOGUS_SOURCE", "path": "/documentation/never-in-index",
+                 "title": "X", "url": "https://www.swift.org/documentation/cxx-interop/"},
+                {"source": "a", "path": "/documentation/swift"},
+                {"source": "b", "path": "/documentation/internal"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("both" in e for e in errors), errors)
+
+    def test_invalid_type_value_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/",
+                 "type": "totally-bogus-type"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("type" in e for e in errors), errors)
+
+    def test_non_string_type_value_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/",
+                 "type": 12345},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("type" in e for e in errors), errors)
+
+    def test_groupmarker_type_is_rejected_for_external_entry(self):
+        # type "groupMarker" forces the frontend to null out the node's path
+        # (docc-render's NavigatorCardItem.vue), which would silently break
+        # the link — reject it explicitly rather than let it through.
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/",
+                 "type": "groupMarker"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("type" in e for e in errors), errors)
+
+    def test_url_with_leading_or_trailing_whitespace_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/ "},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("whitespace" in e for e in errors), errors)
+
+    def test_scheme_only_url_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"title": "C++ Interop", "url": "https://"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("host" in e for e in errors), errors)
+
+    def test_hidden_entry_duplicating_group_url_reports_once(self):
+        url = "https://www.swift.org/documentation/cxx-interop/"
+        nav = self._nav(
+            groups=[{"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+                {"title": "C++ Interop", "url": url},
+            ]}],
+            hidden=[{"title": "C++ Interop (dup)", "url": url}],
+        )
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        hidden_errors = [e for e in errors if "not valid under 'hidden'" in e]
+        self.assertEqual(len(hidden_errors), 1, errors)
+        self.assertFalse(any("appears more than once" in e for e in errors), errors)
 
 
 class CurateNavigator(unittest.TestCase):
@@ -1568,6 +1677,27 @@ class CurateNavigator(unittest.TestCase):
         self.assertTrue(external["external"])
         self.assertNotIn("children", external)
 
+    def test_external_entry_survives_repeated_curation(self):
+        # Re-curating an already-curated archive (e.g. validate_navigation.py
+        # dry-running against a prior build) must not treat a previously
+        # synthesized external node as a real merged module.
+        nav = {
+            "version": 1,
+            "groups": [{"title": "Interoperability", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+                {"title": "C++ Interop", "url": "https://www.swift.org/documentation/cxx-interop/"},
+            ]}],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [_module("Swift", "/documentation/swift")])
+            curate_navigator.curate_navigator(archive, nav)
+            once = (archive / "index" / "index.json").read_bytes()
+            curate_navigator.curate_navigator(archive, nav)
+            twice = (archive / "index" / "index.json").read_bytes()
+
+        self.assertEqual(once, twice)
+
     def test_external_entry_honors_explicit_type(self):
         nav = {
             "version": 1,
@@ -1598,6 +1728,55 @@ class CurateNavigator(unittest.TestCase):
             # Should not raise: the external entry has no path to be dangling
             # or unlisted against the merged index.
             curate_navigator.curate_navigator(archive, nav)
+
+    def test_hybrid_entry_raises_even_without_prior_validation(self):
+        # curate_navigator()/dry_run() take no sources.json and can't call
+        # validate_navigation() themselves — they must defend against a
+        # hybrid entry on their own, not rely on a caller having validated
+        # first (every test in this class calls curate_navigator directly,
+        # same as a hypothetical future caller that skips validation).
+        # No other module in the index, so the only way this can raise is
+        # the explicit hybrid check — not a coincidental dangling/unlisted
+        # collision on '/documentation/nonexistent'.
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [])
+            nav = {
+                "version": 1,
+                "groups": [{"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/nonexistent",
+                     "title": "Hijacked!", "url": "https://evil.example.com/"},
+                ]}],
+                "hidden": [],
+            }
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.curate_navigator(archive, nav)
+
+    def test_groupmarker_type_raises_even_without_prior_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [])
+            nav = {
+                "version": 1,
+                "groups": [{"title": "Language", "modules": [
+                    {"title": "Dead Link", "url": "https://example.com/",
+                     "type": "groupMarker"},
+                ]}],
+                "hidden": [],
+            }
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.curate_navigator(archive, nav)
+
+    def test_missing_title_on_external_entry_raises_even_without_prior_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [])
+            nav = {
+                "version": 1,
+                "groups": [{"title": "Language", "modules": [
+                    {"url": "https://example.com/"},
+                ]}],
+                "hidden": [],
+            }
+            with self.assertRaises(curate_navigator.NavigationError):
+                curate_navigator.curate_navigator(archive, nav)
 
     def test_malformed_index_raises(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Adds a touch more "hacking" to the index.json structure of the combined docs to enable us to author left-nav references in the resulting combined documentation archive that link out to external content, specifically to reference content that remains (at the moment) on www.swift.org as historical docs.

- adds the capability to specify external links in navigation.json
- extends the notes on how we're tweaking index.json beyond the authoring supported directly in DocC today
- closes up some testing and validation gaps with the additional logic
