### PR TITLE
updates the common footer for the combined documentation

### DIFF
--- a/common/README
+++ b/common/README
@@ -11,10 +11,24 @@ Both files are intentionally minimal:
 - `header.html` has no visible content. It's a reserved hook (DocC's
   `custom-header` template) for a future documentation-version switcher —
   add the switcher UI to the `#version-switcher` div when that lands.
-- `footer.html` is just a copyright line, styled with DocC's own CSS custom
+- `footer.html` carries the copyright/trademark notice, the same legal links
+  (License, Security, Privacy Policy, Cookies) swift.org's footer has, and
+  an Adobe Analytics page-activation snippet mirroring swift.org's
+  (`s_account = "awdswiftorg"`). It's styled with DocC's own CSS custom
   properties (e.g. `var(--color-text)`) rather than hardcoded colors, so it
   flips with the page's light/dark mode. It intentionally does not implement
   a manual light/dark toggle: any custom-footer template suppresses DocC's
   native `Footer` component (the one that implements the real toggle), so
   color scheme here is auto-only, following the browser's
   `prefers-color-scheme` via DocC's default CSS.
+  The copyright line uses a `{{COPYRIGHT_YEAR}}` placeholder that
+  `scripts/build_docs.py`'s `render_common_template()` substitutes with the
+  current year at build time, so it doesn't need an annual manual bump.
+  The analytics snippet deliberately differs from swift.org's in one way:
+  it never calls `document.write()`. swift.org's footer is parsed inline by
+  the browser, but this file gets cloned into a `<template>` and
+  `appendChild`'d into a Shadow DOM by swift-docc-render, and `document.write`
+  from a script inserted that way is spec'd to wipe the whole page. The
+  vendored Adobe library fires its tracking beacon itself (via an `Image()`
+  request) as a side effect of calling `s.t()`, so dropping `document.write`
+  doesn't lose the actual tracking call — only a legacy fallback pixel.

--- a/common/footer.html
+++ b/common/footer.html
@@ -9,8 +9,32 @@
 -->
 <style>
 footer.minimal-footer{padding:1.5rem;text-align:center;font-size:12px;color:var(--color-text);}
+footer.minimal-footer a{color:var(--color-text);}
+footer.minimal-footer nav ul{list-style:none;padding:0;margin:0.5rem 0 0;display:flex;justify-content:center;gap:0.75rem;flex-wrap:wrap;}
 </style>
 
 <footer id="footer" class="minimal-footer">
-  <p>Copyright &copy; 2026 Apple Inc. and the Swift project authors.</p>
+  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. All rights reserved.</p>
+  <p>Swift and the Swift logo are trademarks of Apple Inc.</p>
+  <nav aria-label="Legal">
+    <ul>
+      <li><a href="https://www.swift.org/legal/license.html">License</a></li>
+      <li><a href="https://www.swift.org/support/security.html">Security</a></li>
+      <li><a href="https://www.apple.com/privacy/privacy-policy/">Privacy Policy</a></li>
+      <li><a href="https://www.apple.com/legal/privacy/en-ww/cookies/">Cookies</a></li>
+    </ul>
+  </nav>
 </footer>
+
+<script>var s_account = "awdswiftorg";</script>
+<script>
+(function () {
+  var script = document.createElement("script");
+  script.src = "https://developer.apple.com/assets/metrics/scripts/analytics.js";
+  script.onload = function () {
+    window.s.pageName = window.AC && window.AC.Tracking && window.AC.Tracking.pageName();
+    window.s.t();
+  };
+  document.head.appendChild(script);
+})();
+</script>

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -429,6 +429,13 @@ def find_docc_catalog_for_target(source_dir, target):
     return None
 
 
+def render_common_template(text, year=None):
+    """Substitute the {{COPYRIGHT_YEAR}} placeholder used in common/*.html."""
+    if year is None:
+        year = datetime.now(timezone.utc).year
+    return text.replace("{{COPYRIGHT_YEAR}}", str(year))
+
+
 def install_templates(catalog_dir, common_dir, source_id):
     """Copy common template files (header.html, footer.html) into a .docc catalog."""
     for tmpl in TEMPLATE_FILES:
@@ -436,7 +443,7 @@ def install_templates(catalog_dir, common_dir, source_id):
         dst = catalog_dir / tmpl
         if dst.exists():
             print(f"  WARNING: overwriting existing {tmpl} in {source_id} catalog")
-        shutil.copy2(str(src), str(dst))
+        dst.write_text(render_common_template(src.read_text()))
         print(f"  Installed {tmpl} -> {catalog_dir}/")
 
 
@@ -747,8 +754,8 @@ def inject_custom_templates_into_stubs(archive_path, common_dir):
     after `<body data-color-scheme="auto">` to mirror the placement
     docc convert produces in the root. Returns the number of stubs patched.
     """
-    header = (common_dir / "header.html").read_text()
-    footer = (common_dir / "footer.html").read_text()
+    header = render_common_template((common_dir / "header.html").read_text())
+    footer = render_common_template((common_dir / "footer.html").read_text())
     anchor = '<body data-color-scheme="auto">'
     # Mirror docc convert ordering: footer template first, then header.
     injection = (

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1021,6 +1021,64 @@ class FinalizeCombinedArchive(unittest.TestCase):
         self.assertEqual(failed, [])
 
 
+class RenderCommonTemplate(unittest.TestCase):
+    def test_substitutes_copyright_year_placeholder(self):
+        rendered = build_docs.render_common_template(
+            "Copyright (c) {{COPYRIGHT_YEAR}} Apple Inc.", year=2031
+        )
+        self.assertEqual(rendered, "Copyright (c) 2031 Apple Inc.")
+
+    def test_defaults_to_current_utc_year_when_not_given(self):
+        from datetime import datetime, timezone
+
+        expected_year = datetime.now(timezone.utc).year
+        rendered = build_docs.render_common_template("{{COPYRIGHT_YEAR}}")
+        self.assertEqual(rendered, str(expected_year))
+
+    def test_no_op_when_placeholder_absent(self):
+        rendered = build_docs.render_common_template("no placeholder here", year=2031)
+        self.assertEqual(rendered, "no placeholder here")
+
+    def test_substitutes_multiple_occurrences(self):
+        rendered = build_docs.render_common_template(
+            "{{COPYRIGHT_YEAR}} and {{COPYRIGHT_YEAR}}", year=2031
+        )
+        self.assertEqual(rendered, "2031 and 2031")
+
+
+class InstallTemplates(unittest.TestCase):
+    def test_substitutes_copyright_year_in_installed_footer(self):
+        from datetime import datetime, timezone
+
+        expected_year = datetime.now(timezone.utc).year
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            common = root / "common"
+            common.mkdir()
+            (common / "header.html").write_text("HDR")
+            (common / "footer.html").write_text("Copyright {{COPYRIGHT_YEAR}}")
+            catalog = root / "Foo.docc"
+            catalog.mkdir()
+            build_docs.install_templates(catalog, common, "foo")
+            self.assertEqual(
+                (catalog / "footer.html").read_text(), f"Copyright {expected_year}"
+            )
+            self.assertEqual((catalog / "header.html").read_text(), "HDR")
+
+    def test_warns_and_overwrites_existing_template(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            common = root / "common"
+            common.mkdir()
+            (common / "header.html").write_text("HDR")
+            (common / "footer.html").write_text("FTR")
+            catalog = root / "Foo.docc"
+            catalog.mkdir()
+            (catalog / "footer.html").write_text("stale")
+            build_docs.install_templates(catalog, common, "foo")
+            self.assertEqual((catalog / "footer.html").read_text(), "FTR")
+
+
 class InjectCustomTemplatesIntoStubs(unittest.TestCase):
     """Workaround for swiftlang/swift-docc#1532: see build_docs function docstring."""
 
@@ -1120,6 +1178,21 @@ class InjectCustomTemplatesIntoStubs(unittest.TestCase):
             (common / "footer.html").write_text("FTR")
             patched = build_docs.inject_custom_templates_into_stubs(archive, common)
             self.assertEqual(patched, 0)
+
+    def test_substitutes_copyright_year_placeholder_in_stubs(self):
+        from datetime import datetime, timezone
+
+        expected_year = datetime.now(timezone.utc).year
+        with tempfile.TemporaryDirectory() as tmp:
+            archive, common = self._make_archive(
+                Path(tmp), "HDR", "Copyright {{COPYRIGHT_YEAR}}"
+            )
+            build_docs.inject_custom_templates_into_stubs(archive, common)
+            text = (archive / "documentation" / "index.html").read_text()
+            self.assertIn(
+                f'<template id="custom-footer">Copyright {expected_year}</template>',
+                text,
+            )
 
     def test_template_ordering_matches_docc_convert(self):
         """custom-footer comes before custom-header — same order docc convert emits."""


### PR DESCRIPTION
 - brings in copyright statement from swift.org 
 - sets single Copyright year from the time of rendering, matching structurally what we're doing in swift.org 
 - adds in a simple replacement mechanism in build_docs.py to tweak that value explicitly (short of a full jinja-like rendering dependency) 
 - brings in the cross links to license, security, privacy policy, and cookies statements for Apple-hosted content 
 - injects in analytics header marker, using the same code as www.swift.org to capture basic reading analytics