### PR TITLE
left-nav re-org and updates per review

### DIFF
--- a/libraries/Package.swift
+++ b/libraries/Package.swift
@@ -3,16 +3,16 @@
 import PackageDescription
 
 let package = Package(
-  name: "OfficialLibraries",
+  name: "Libraries",
   products: [
-    .library(name: "OfficialLibraries", targets: ["OfficialLibraries"])
+    .library(name: "Libraries", targets: ["Libraries"])
   ],
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
   ],
   targets: [
     .target(
-      name: "OfficialLibraries",
+      name: "Libraries",
       path: "Sources"
     )
   ]

--- a/libraries/Sources/Libraries.docc/Documentation.md
+++ b/libraries/Sources/Libraries.docc/Documentation.md
@@ -1,9 +1,9 @@
-# ``OfficialLibraries``
+# ``Libraries``
 
 Official libraries maintained by the Swift project.
 
 @Metadata {
-    @DisplayName("Official Libraries")
+    @DisplayName("Project Libraries")
     @TitleHeading("")
 }
 

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -4,8 +4,7 @@
     {
       "title": "Swift",
       "modules": [
-        { "source": "swift-book", "path": "/documentation/the-swift-programming-language", "title": "The Swift Programming Language" },
-        { "source": "compiler-diagnostics", "path": "/documentation/diagnostics" }
+        { "source": "swift-book", "path": "/documentation/the-swift-programming-language", "title": "The Swift Programming Language" }
        ]
     },
     {
@@ -13,7 +12,7 @@
       "modules": [
         { "source": "swift-stdlib", "path": "/documentation/swift", "title": "Standard Library" },
         { "source": "swift-testing", "path": "/documentation/testing" },
-        { "source": "official-libraries", "path": "/documentation/officiallibraries", "title": "Official Libraries" }
+        { "source": "libraries", "path": "/documentation/libraries", "title": "Project libraries" }
       ]
     },
     {
@@ -51,8 +50,9 @@
       ]
     },
     {
-      "title": "Releases",
+      "title": "References",
       "modules": [
+        { "source": "compiler-diagnostics", "path": "/documentation/diagnostics", "title": "Compiler diagnostics" },
         { "source": "swift-migration-guide", "path": "/documentation/migrationguide" }
       ]
     }

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -84,10 +84,10 @@
       "targets": ["SwiftWindows"]
     },
     {
-      "id": "official-libraries",
+      "id": "libraries",
       "type": "local",
       "path": "libraries",
-      "targets": ["OfficialLibraries"]
+      "targets": ["Libraries"]
     },
     {
       "id": "swift-android",


### PR DESCRIPTION
 - change "Releases" delimiter to "References"
 - move migration guide content under References
 - rename "official libraries" to "project libraries"
 - rename "Swift compiler diagnostics" to "Compiler diagnostics"
