### PR TITLE
injecting references to legacy articles

### DIFF
--- a/linux/Sources/SwiftLinux.docc/ServerGuides.md
+++ b/linux/Sources/SwiftLinux.docc/ServerGuides.md
@@ -7,3 +7,4 @@ Build, package, and deploy Swift applications for Linux servers and cloud infras
 - <doc:building>
 - <doc:packaging>
 - <doc:deploying-static-binaries>
+- <doc:prior-articles>

--- a/linux/Sources/SwiftLinux.docc/prior-articles.md
+++ b/linux/Sources/SwiftLinux.docc/prior-articles.md
@@ -1,0 +1,26 @@
+# Prior articles
+
+Swift on Server guides that haven't yet moved into this documentation collection.
+
+## Overview
+
+These pages still live on swift.org's own site rather than in this combined
+documentation. Each link below goes to the existing page until its content
+migrates into this catalog.
+
+- [Swift on Server Guides](https://www.swift.org/documentation/server/guides/index.html) — Index of guides for building, testing, deploying, and debugging server applications.
+- [Testing](https://www.swift.org/documentation/server/guides/testing.html)
+- [Optimizing Allocations](https://www.swift.org/documentation/server/guides/allocations.html)
+- [Linux perf](https://www.swift.org/documentation/server/guides/linux-perf.html)
+- [LLVM TSAN / ASAN](https://www.swift.org/documentation/server/guides/llvm-sanitizers.html) — Debugging multithreading issues and memory checks.
+- [Debugging Memory Leaks and Usage](https://www.swift.org/documentation/server/guides/memory-leaks-and-usage.html)
+- [Going Passwordless with Passkeys](https://www.swift.org/documentation/server/guides/passkeys.html)
+- [Debugging Performance Issues](https://www.swift.org/documentation/server/guides/performance.html)
+- [Log Levels](https://www.swift.org/documentation/server/guides/libraries/log-levels.html)
+- [Deploying to AWS on Amazon Linux 2](https://www.swift.org/documentation/server/guides/deploying/aws.html)
+- [Deploying to AWS Lambda using the Serverless Application Model (SAM)](https://www.swift.org/documentation/server/guides/deploying/aws-sam-lambda.html)
+- [Deploying to AWS with Fargate, Vapor, and MongoDB Atlas](https://www.swift.org/documentation/server/guides/deploying/aws-copilot-fargate-vapor-mongo.html)
+- [Deploying to DigitalOcean](https://www.swift.org/documentation/server/guides/deploying/digital-ocean.html)
+- [Deploying to Google Cloud Platform (GCP)](https://www.swift.org/documentation/server/guides/deploying/gcp.html)
+- [Deploying to Heroku](https://www.swift.org/documentation/server/guides/deploying/heroku.html)
+- [Deploying on Ubuntu](https://www.swift.org/documentation/server/guides/deploying/ubuntu.html)

--- a/prior/Package.swift
+++ b/prior/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+  name: "PriorArticles",
+  products: [
+    .library(name: "PriorArticles", targets: ["PriorArticles"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
+  ],
+  targets: [
+    .target(
+      name: "PriorArticles",
+      path: "Sources"
+    )
+  ]
+)

--- a/prior/Sources/PriorArticles.docc/Documentation.md
+++ b/prior/Sources/PriorArticles.docc/Documentation.md
@@ -1,0 +1,30 @@
+# ``PriorArticles``
+
+Legacy swift.org articles and guides that haven't yet moved into this
+documentation collection.
+
+@Metadata {
+    @DisplayName("Prior articles")
+    @TitleHeading("")
+}
+
+These pages still live on swift.org's own site rather than in this combined
+documentation. Each link below goes to the existing page until its content
+migrates into one of the catalogs here.
+
+## Reference and design guidance
+
+- [API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/) — Naming and idioms for a consistent Swift API.
+- [Value and Reference Types](https://www.swift.org/documentation/articles/value-and-reference-types.html) — How value types and reference types differ, and why it matters.
+- [Wrapping a C/C++ Library in Swift](https://www.swift.org/documentation/articles/wrapping-c-cpp-library-in-swift.html) — Exposing an existing C or C++ library to Swift code.
+- [REPL & Debugger](https://www.swift.org/documentation/lldb/) — The LLDB debugger and the REPL it provides for the Swift language.
+
+## Getting started guides
+
+- [Getting Started with the Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html) — Building Linux binaries with no system dependencies, including the Swift runtime.
+- [Getting Started with the Swift SDK for Android](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html) — Cross-compiling Swift packages for Android.
+- [Getting Started with Swift SDKs for WebAssembly](https://www.swift.org/documentation/articles/wasm-getting-started.html) — Building Swift packages for WebAssembly (Wasm).
+- [Getting Started with Swift on VS Code](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) — Setting up the Swift extension for Visual Studio Code.
+- [Setting up Cursor for Swift Development](https://www.swift.org/documentation/articles/getting-started-with-cursor-swift.html) — Configuring the Cursor editor for Swift.
+- [Configuring Emacs for Swift Development](https://www.swift.org/documentation/articles/zero-to-swift-emacs.html) — Setting up Emacs for Swift development.
+- [Configuring Neovim for Swift Development](https://www.swift.org/documentation/articles/zero-to-swift-nvim.html) — Setting up Neovim for Swift development.

--- a/prior/Sources/_empty.swift
+++ b/prior/Sources/_empty.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -54,7 +54,8 @@
       "title": "References",
       "modules": [
         { "source": "compiler-diagnostics", "path": "/documentation/diagnostics", "title": "Compiler diagnostics" },
-        { "source": "swift-migration-guide", "path": "/documentation/migrationguide" }
+        { "source": "swift-migration-guide", "path": "/documentation/migrationguide" },
+        { "source": "prior-articles", "path": "/documentation/priorarticles", "title": "Prior articles" }
       ]
     }
   ],

--- a/scripts/sources.json
+++ b/scripts/sources.json
@@ -132,6 +132,12 @@
       "env": {
         "SWIFTJAVA_DOCC_PLUGIN_INSTALL": "1"
       }
+    },
+    {
+      "id": "prior-articles",
+      "type": "local",
+      "path": "prior",
+      "targets": ["PriorArticles"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

adds a collection of "prior articles" that includes links to the legacy content hosted under www.swift.org/documentation/ from two locations:
- including in Linux for server guides
- separate "Prior articles" collection under References

This is to ensure that the content is still navigable by browsing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
