### PR TITLE
updating ordering of testing and libraries

### DIFF
--- a/libraries/Sources/Libraries.docc/Documentation.md
+++ b/libraries/Sources/Libraries.docc/Documentation.md
@@ -7,10 +7,6 @@ Official libraries maintained by the Swift project.
     @TitleHeading("")
 }
 
-## Foundation
-
-- [swift-foundation](https://swiftpackageindex.com/swiftlang/swift-foundation) — The foundation project
-
 ## Concurrency and process libraries
 
 - [swift-subprocess](https://swiftpackageindex.com/swiftlang/swift-subprocess) — Cross-platform process spawning package

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -12,18 +12,19 @@
       "modules": [
         { "source": "swift-stdlib", "path": "/documentation/swift", "title": "Standard Library" },
         { "source": "swift-testing", "path": "/documentation/testing" },
-        { "source": "libraries", "path": "/documentation/libraries", "title": "Project libraries" }
+        { "title": "Foundation", "url": "https://swiftpackageindex.com/swiftlang/swift-foundation" },
+        { "source": "libraries", "path": "/documentation/libraries", "title": "Swift project libraries" }
       ]
     },
     {
       "title": "Tools",
       "modules": [
-        { "source": "docc-documentation", "path": "/documentation/docc", "title": "Documentation (DocC)" },
+        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Installer (Swiftly)" },
+        { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "IDE Integration" },
         { "source": "swiftpm", "path": "/documentation/packagemanagerdocs", "title": "Package Manager (SwiftPM)" },
         { "source": "swiftpm", "path": "/documentation/packagedescription" },
         { "source": "swiftpm", "path": "/documentation/packageplugin" },
-        { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "IDE Integration" },
-        { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Installer (Swiftly)" }
+        { "source": "docc-documentation", "path": "/documentation/docc", "title": "Documentation (DocC)" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

  - Update the title “Project libraries” to “Swift project libraries”
  - Add Foundation (link external) beneath testing to https://swiftpackageindex.com/swiftlang/swift-foundation
  - remove Foundation link from within the project libraries page
  - Change ordering of “Tools” → Installer, IDE Integration, Package Manager (SwiftPM), PackageDescription, PackagePlugin, Documentation (DocC)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
