### PR TITLE
amending general copyright for Swift docs to reference Swift project authors

### DIFF
--- a/common/footer.html
+++ b/common/footer.html
@@ -14,7 +14,7 @@ footer.minimal-footer nav ul{list-style:none;padding:0;margin:0.5rem 0 0;display
 </style>
 
 <footer id="footer" class="minimal-footer">
-  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. All rights reserved.</p>
+  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. and the Swift project authors. All rights reserved.</p>
   <p>Swift and the Swift logo are trademarks of Apple Inc.</p>
   <nav aria-label="Legal">
     <ul>


### PR DESCRIPTION
## Summary

Adds "and Swift project authors" to the copyright holder attribution, per legal feedback

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
