### PR TITLE
Revert "ammending copyright to reference Swift project authors as well"

### DIFF
--- a/common/footer.html
+++ b/common/footer.html
@@ -14,7 +14,7 @@ footer.minimal-footer nav ul{list-style:none;padding:0;margin:0.5rem 0 0;display
 </style>
 
 <footer id="footer" class="minimal-footer">
-  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. and the Swift project authors. All rights reserved.</p>
+  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. All rights reserved.</p>
   <p>Swift and the Swift logo are trademarks of Apple Inc.</p>
   <nav aria-label="Legal">
     <ul>


### PR DESCRIPTION
## Summary
- Reverts 83bf4c27, which was pushed directly to `main` without review.
- The underlying change (crediting Swift project authors in the copyright line) is being re-proposed separately as a PR so it can get discussion before landing.

This reverts commit 83bf4c2711db335b442e47c861f33df13d2f66a7.