### PR TITLE
Amend copyright to reference Swift project authors as well

### DIFF
--- a/common/footer.html
+++ b/common/footer.html
@@ -14,7 +14,7 @@ footer.minimal-footer nav ul{list-style:none;padding:0;margin:0.5rem 0 0;display
 </style>
 
 <footer id="footer" class="minimal-footer">
-  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. All rights reserved.</p>
+  <p>Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. and the Swift project authors. All rights reserved.</p>
   <p>Swift and the Swift logo are trademarks of Apple Inc.</p>
   <nav aria-label="Legal">
     <ul>


### PR DESCRIPTION
## Summary
- Updates Copyright attribution from:

`Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. All rights reserved.`

to

`Copyright &copy; {{COPYRIGHT_YEAR}} Apple Inc. and the Swift project authors. All rights reserved.`

## Test plan
- [ ] Confirm the exact copyright attribution wording is agreed upon before merging.