### PR TITLE
Point “Foundation” left-nav link to developer.apple.com

### DIFF
--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -12,7 +12,7 @@
       "modules": [
         { "source": "swift-stdlib", "path": "/documentation/swift", "title": "Standard Library" },
         { "source": "swift-testing", "path": "/documentation/testing" },
-        { "title": "Foundation", "url": "https://swiftpackageindex.com/swiftlang/swift-foundation" },
+        { "title": "Foundation", "url": "https://developer.apple.com/documentation/foundation" },
         { "source": "libraries", "path": "/documentation/libraries", "title": "Swift project libraries" }
       ]
     },


### PR DESCRIPTION
## Summary

Pointing content for Foundation to Apple's developer documentation (https://developer.apple.com/documentation/foundation) until we have open source built documentation for foundation available and included in this collection of Swift project documentation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
