### PR TITLE
Show "Platforms" eyebrow on Apple platforms, Linux, and Windows

### DIFF
--- a/apple-platforms/Sources/SwiftApplePlatforms.docc/Documentation.md
+++ b/apple-platforms/Sources/SwiftApplePlatforms.docc/Documentation.md
@@ -4,7 +4,7 @@ Build and ship apps for iOS, iPadOS, macOS, watchOS, tvOS, and visionOS.
 
 @Metadata {
     @DisplayName("Apple platforms")
-    @TitleHeading("")
+    @TitleHeading("Platforms")
 }
 
 Swift is the primary language for building apps across Apple's platforms, with

--- a/linux/Sources/SwiftLinux.docc/Documentation.md
+++ b/linux/Sources/SwiftLinux.docc/Documentation.md
@@ -4,7 +4,7 @@ Build and host libraries, apps, and services on Linux.
 
 @Metadata {
     @DisplayName("Linux")
-    @TitleHeading("")
+    @TitleHeading("Platforms")
 }
 
 ## Topics

--- a/windows/Sources/SwiftWindows.docc/Documentation.md
+++ b/windows/Sources/SwiftWindows.docc/Documentation.md
@@ -4,7 +4,7 @@ Build and run Swift on Windows.
 
 @Metadata {
     @DisplayName("Windows")
-    @TitleHeading("")
+    @TitleHeading("Platforms")
 }
 
 Swift supports native development on Windows, including a downloadable


### PR DESCRIPTION
## Summary
- Apple platforms, Linux, and Windows belong to the "Platforms" nav group in `scripts/navigation.json`, but their DocC landing pages had `@TitleHeading("")`, so no eyebrow rendered above the title.
- Sets `@TitleHeading("Platforms")` on all three so the page eyebrow matches the nav grouping.

## Test plan
- [x] `swift package generate-documentation --analyze --warnings-as-errors` passes in `apple-platforms/`, `linux/`, and `windows/`
- [ ] Visually confirm the "Platforms" eyebrow renders above the title via `swift package --disable-sandbox preview-documentation`