### PR TITLE
Hide the Swift Server tutorial from the combined nav, link it from Server Guides

### DIFF
--- a/linux/Sources/SwiftLinux.docc/ServerGuides.md
+++ b/linux/Sources/SwiftLinux.docc/ServerGuides.md
@@ -2,6 +2,10 @@
 
 Build, package, and deploy Swift applications for Linux servers and cloud infrastructure.
 
+## Tutorials
+
+- [Get Started with Swift Server](https://docs.swift.org/latest/tutorials/getting-started-swift-server) — Explore Swift on the server by building a Vapor app.
+
 ## Topics
 
 - <doc:building>

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -37,12 +37,6 @@
       ]
     },
     {
-      "title": "Tutorials",
-      "modules": [
-        { "source": "swift-server-todos-tutorial", "path": "/tutorials/getting-started-swift-server" }
-      ]
-    },
-    {
       "title": "Interoperability",
       "modules": [
         { "source": "swift-java", "path": "/documentation/swiftjavadocumentation", "title": "Swift and Java" },
@@ -61,6 +55,7 @@
   "hidden": [
     { "source": "swiftpm", "path": "/documentation/packagedescription" },
     { "source": "swiftpm", "path": "/documentation/packageplugin" },
+    { "source": "swift-server-todos-tutorial", "path": "/tutorials/getting-started-swift-server" },
     { "source": "swift-stdlib", "path": "/documentation/cxx" },
     { "source": "swift-stdlib", "path": "/documentation/cxxstdlib" },
     { "source": "swift-stdlib", "path": "/documentation/distributed" },


### PR DESCRIPTION
## Summary
- Removes the standalone "Tutorials" group from `scripts/navigation.json` and moves `swift-server-todos-tutorial` into `hidden`, suppressing it from the combined docs' left nav while keeping `navigation.json` complete against `sources.json`.
- Adds a hand-assembled `## Tutorials` section above `## Topics` on the Linux "Server Guides" page (`linux/Sources/SwiftLinux.docc/ServerGuides.md`) linking to the tutorial, since DocC's `## Topics` curation can't reference content in another catalog.

## Test plan
- [x] `python3 scripts/validate_navigation.py` passes (navigation.json valid, all sources represented)
- [ ] `swift package generate-documentation --analyze --warnings-as-errors` from `linux/`