### PR TITLE
Show "References" eyebrow on the prior articles landing page

### DIFF
--- a/libraries/Sources/Libraries.docc/Documentation.md
+++ b/libraries/Sources/Libraries.docc/Documentation.md
@@ -4,7 +4,7 @@ Official libraries maintained by the Swift project.
 
 @Metadata {
     @DisplayName("Project Libraries")
-    @TitleHeading("")
+    @TitleHeading("Libraries")
 }
 
 ## Concurrency and process libraries

--- a/prior/Sources/PriorArticles.docc/Documentation.md
+++ b/prior/Sources/PriorArticles.docc/Documentation.md
@@ -5,7 +5,7 @@ documentation collection.
 
 @Metadata {
     @DisplayName("Prior articles")
-    @TitleHeading("")
+    @TitleHeading("References")
 }
 
 These pages still live on swift.org's own site rather than in this combined


### PR DESCRIPTION
## Summary
- The "Prior articles" module belongs to the "References" nav group, but its title heading was set to an empty string, so no eyebrow was shown — same issue as #129 for the "Platforms" group.

## Test plan
- [x] `swift package generate-documentation --analyze --warnings-as-errors` passes in `prior/`