### PR TITLE
suppress SwiftPM API reference catalogs from navigation

### DIFF
--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -22,8 +22,6 @@
         { "source": "swiftly", "path": "/documentation/swiftlydocs", "title": "Installer (Swiftly)" },
         { "source": "vscode-swift", "path": "/documentation/userdocs", "title": "IDE Integration" },
         { "source": "swiftpm", "path": "/documentation/packagemanagerdocs", "title": "Package Manager (SwiftPM)" },
-        { "source": "swiftpm", "path": "/documentation/packagedescription" },
-        { "source": "swiftpm", "path": "/documentation/packageplugin" },
         { "source": "docc-documentation", "path": "/documentation/docc", "title": "Documentation (DocC)" }
       ]
     },
@@ -61,6 +59,8 @@
     }
   ],
   "hidden": [
+    { "source": "swiftpm", "path": "/documentation/packagedescription" },
+    { "source": "swiftpm", "path": "/documentation/packageplugin" },
     { "source": "swift-stdlib", "path": "/documentation/cxx" },
     { "source": "swift-stdlib", "path": "/documentation/cxxstdlib" },
     { "source": "swift-stdlib", "path": "/documentation/distributed" },


### PR DESCRIPTION
## Summary

suppress SwiftPM API reference catalogs from navigation
- PackageDescription
- PackagePlugin

Hiding these after discussion with Tracy Miranda and Dave Verwer with the idea to so some creative DocC catalog build and curation processes to "inline" them as additional API reference content within the broader SwiftPM content down the road.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
