### PR TITLE
Removes the duplicate "Swift" header in the left nav of the resulting combined docs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,10 @@ in the merged index must be either placed in a group or listed under `hidden` �
 `navigator-curation` build step), and fails the build on any mismatch or
 uncovered module. See `../hacking-index-json.md` for the underlying mechanics.
 
+A group's `title` is optional — omit it (or set it to `null`) for a headerless
+group whose modules render with no section label in either the sidebar or the
+landing page.
+
 A group's `modules` list may also contain **external-link entries** — plain
 links to content outside the archive, with no backing `sources.json` id. Give
 these a `title` and an `https://` `url` instead of `source`/`path`:

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -167,16 +167,20 @@ def validate_navigation(navigation, sources_config):
     if not isinstance(hidden, list):
         errors.append("navigation.json: 'hidden' must be a list")
 
-    # Per-group shape.
+    # Per-group shape. `title` is optional: omit it (or set it to null) for a
+    # headerless group, whose modules render with no groupMarker in the
+    # sidebar and no titled section on the landing page. When present it
+    # must be a non-empty string.
     for i, group in enumerate(groups):
         if not isinstance(group, dict):
             errors.append(f"navigation.json: group #{i} must be an object")
             continue
-        if not group.get("title"):
-            errors.append(f"navigation.json: group #{i} is missing a non-empty 'title'")
+        title = group.get("title")
+        if title is not None and not (isinstance(title, str) and title):
+            errors.append(f"navigation.json: group #{i} has an invalid 'title' "
+                          "(must be a non-empty string, or omitted/null for no header)")
         if not isinstance(group.get("modules", []), list):
-            errors.append(f"navigation.json: group '{group.get('title')}' "
-                          "'modules' must be a list")
+            errors.append(f"navigation.json: group #{i} 'modules' must be a list")
 
     # Per-entry shape, duplicate paths/urls, and source linkage.
     source_ids = {s.get("id") for s in sources_config.get("sources", [])}
@@ -309,7 +313,8 @@ def _curate_children(children, navigation):
 
     new_children = []
     for group in navigation.get("groups", []):
-        new_children.append({"type": "groupMarker", "title": group["title"]})
+        if group.get("title"):
+            new_children.append({"type": "groupMarker", "title": group["title"]})
         for entry in group.get("modules", []):
             if _is_external_entry(entry):
                 shape_errors, _ = _external_entry_shape_errors(entry, "group")
@@ -390,7 +395,8 @@ def _curate_landing_page(archive_path, navigation):
 
       * one ``topicSection`` per ``navigation.groups`` entry, in declared order,
         titled by the group's ``title``, with identifiers in the group's
-        ``modules`` order;
+        ``modules`` order; a group with no ``title`` produces a section with
+        no ``title``/``anchor`` key, so its modules appear with no header;
       * groups whose modules don't match any identifier on the page are
         dropped (e.g. a nav module the merge step never surfaced as a card);
       * each kept identifier's reference is forced to ``kind:"symbol"``,
@@ -426,11 +432,14 @@ def _curate_landing_page(archive_path, navigation):
             if ident is not None:
                 group_idents.append(ident)
         if group_idents:
-            new_sections.append({
-                "title": group["title"],
-                "identifiers": group_idents,
-                "anchor": _section_anchor(group["title"]),
-            })
+            title = group.get("title")
+            section = {}
+            if title:
+                section["title"] = title
+            section["identifiers"] = group_idents
+            if title:
+                section["anchor"] = _section_anchor(title)
+            new_sections.append(section)
             placed_idents.extend(group_idents)
     doc["topicSections"] = new_sections
 

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -2,7 +2,6 @@
   "version": 1,
   "groups": [
     {
-      "title": "Swift",
       "modules": [
         { "source": "swift-book", "path": "/documentation/the-swift-programming-language", "title": "The Swift Programming Language" }
        ]

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -1448,6 +1448,21 @@ class ValidateNavigation(unittest.TestCase):
         errors = curate_navigator.validate_navigation(nav, self.SOURCES)
         self.assertTrue(errors)
 
+    def test_group_with_omitted_title_is_valid(self):
+        # Omitting `title` entirely means "no visible header" for this
+        # group's modules — distinct from an explicit empty string, which is
+        # still rejected above.
+        nav = self._nav(groups=[{"modules": [
+            {"source": "a", "path": "/documentation/swift"},
+        ]}])
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
+    def test_group_with_null_title_is_valid(self):
+        nav = self._nav(groups=[{"title": None, "modules": [
+            {"source": "a", "path": "/documentation/swift"},
+        ]}])
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
     def test_malformed_entry_missing_path_is_reported(self):
         nav = self._nav(groups=[{"title": "Lang", "modules": [
             {"source": "a"},
@@ -1653,6 +1668,33 @@ class CurateNavigator(unittest.TestCase):
         self.assertEqual(kids[1]["title"], "The Swift Language")
         self.assertEqual(kids[2]["path"], "/documentation/testing")
         self.assertFalse(any(k.get("path") == "/documentation/internal" for k in kids))
+
+    def test_headerless_group_has_no_group_marker(self):
+        # A group with no `title` renders its modules with no preceding
+        # groupMarker, while other groups still get theirs.
+        nav = {
+            "version": 1,
+            "groups": [
+                {"modules": [{"source": "a", "path": "/documentation/swift"}]},
+                {"title": "Language", "modules": [
+                    {"source": "b", "path": "/documentation/testing"},
+                ]},
+            ],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [
+                _module("Swift", "/documentation/swift"),
+                _module("Testing", "/documentation/testing"),
+            ])
+            curate_navigator.curate_navigator(archive, nav)
+            kids = _children_of(archive)
+
+        self.assertEqual(len(kids), 3)
+        self.assertEqual(kids[0]["path"], "/documentation/swift")
+        self.assertNotEqual(kids[0].get("type"), "groupMarker")
+        self.assertEqual(kids[1], {"type": "groupMarker", "title": "Language"})
+        self.assertEqual(kids[2]["path"], "/documentation/testing")
 
     def test_dangling_manifest_path_raises(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2158,6 +2200,38 @@ class CurateLandingPage(unittest.TestCase):
             sections = _landing_sections(archive)
 
         self.assertEqual(sections, [("Language", ["doc://Test/documentation/Swift"])])
+
+    def test_headerless_group_produces_titleless_section(self):
+        nav = {
+            "version": 1,
+            "groups": [
+                {"modules": [{"source": "a", "path": "/documentation/swift"}]},
+                {"title": "Language", "modules": [
+                    {"source": "a", "path": "/documentation/testing"},
+                ]},
+            ],
+            "hidden": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_index(Path(tmp), [
+                _module("Swift", "/documentation/swift"),
+                _module("Testing", "/documentation/testing"),
+            ])
+            _write_landing_page(archive, [
+                ("Modules", [
+                    "doc://Test/documentation/Swift",
+                    "doc://Test/documentation/Testing",
+                ]),
+            ])
+            curate_navigator.curate_navigator(archive, nav)
+            doc = json.loads((archive / "data" / "documentation.json").read_text())
+            sections = doc["topicSections"]
+
+        self.assertNotIn("title", sections[0])
+        self.assertNotIn("anchor", sections[0])
+        self.assertEqual(sections[0]["identifiers"], ["doc://Test/documentation/Swift"])
+        self.assertEqual(sections[1]["title"], "Language")
+        self.assertEqual(sections[1]["anchor"], "Language")
 
     def test_overwrites_kept_reference_kind_and_role(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION

## Summary

updates the schema I'm using for navigation.json, which sets up the organization for the left nav:

- allow title to be optional, in order to enable us to hide first in the list for combined docs
- remove the first title since the name of the project is "Swift Documentation", which makes that first nav grouping header of "Swift" redundant.
- updates tests to validate the schema and how index.json renders based on the changes in navigation.json

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
