### PR TITLE
adds hairline horizontal rule to break SPA content from footer details

### DIFF
--- a/common/footer.html
+++ b/common/footer.html
@@ -8,7 +8,7 @@
   See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 -->
 <style>
-footer.minimal-footer{padding:1.5rem;text-align:center;font-size:12px;color:var(--color-text);}
+footer.minimal-footer{padding:1.5rem;text-align:center;font-size:12px;color:var(--color-text);border-top:1px solid var(--color-grid);}
 footer.minimal-footer a{color:var(--color-text);}
 footer.minimal-footer nav ul{list-style:none;padding:0;margin:0.5rem 0 0;display:flex;justify-content:center;gap:0.75rem;flex-wrap:wrap;}
 </style>


### PR DESCRIPTION
## Summary

The footer for the combined docs was missing a hairline horizontal rule that broke up the content of the single-page app that presents the docs from the footer content below. This adds one in:

<img width="1198" height="1081" alt="Screenshot 2026-08-10 at 12 36 36 PM" src="https://github.com/user-attachments/assets/0f080279-52b7-40e3-b45d-ca55ef75b859" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
