### PR TITLE
adds scripting to surpress the "eyebrows" for modules

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -29,7 +29,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from strip_availability import strip_archive
-from curate_navigator import curate_navigator, validate_navigation, NavigationError
+from suppress_eyebrows import suppress_archive as suppress_eyebrow_archive
+from curate_navigator import (
+    curate_navigator,
+    validate_navigation,
+    collect_eyebrow_overrides,
+    NavigationError,
+)
 
 
 class ArchiveFetchError(Exception):
@@ -828,24 +834,36 @@ def _finalize_combined_archive(all_archives, output_dir, version_slug, docc_cmd,
             print(f"Error: navigator curation failed: {e}")
             return ["combined-merge"], ["navigator-curation"]
 
+    prior_steps = ["combined-merge"]
+    if navigation is not None:
+        prior_steps.append("navigator-curation")
+
+    try:
+        eyebrows_config = {
+            "suppress": ((navigation or {}).get("eyebrows") or {}).get("suppress", False),
+            "overrides": collect_eyebrow_overrides(navigation or {}),
+        }
+        scanned, modified = suppress_eyebrow_archive(combined_output, eyebrows_config)
+        print(f"Eyebrow suppression: scanned {scanned} file(s), modified {modified}.")
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Error: eyebrow suppression failed: {e}")
+        return prior_steps, ["eyebrow-suppression"]
+
+    prior_steps.append("eyebrow-suppression")
+
     try:
         transform_static_hosting(combined_output, hosting_base_path or version_slug, docc_cmd)
     except subprocess.CalledProcessError:
         print("Error: docc process-archive transform-for-static-hosting failed")
-        curated = ["combined-merge"]
-        if navigation is not None:
-            curated.append("navigator-curation")
-        return curated, ["static-hosting-transform"]
+        return prior_steps, ["static-hosting-transform"]
 
     # Workaround for swiftlang/swift-docc#1532 — drop this when fixed.
     if common_dir is not None:
         patched = inject_custom_templates_into_stubs(combined_output, common_dir)
         print(f"Patched custom-header/footer into {patched} per-route stub(s).")
 
-    succeeded = ["combined-merge", "static-hosting-transform"]
-    if navigation is not None:
-        succeeded.insert(1, "navigator-curation")
-    return succeeded, []
+    prior_steps.append("static-hosting-transform")
+    return prior_steps, []
 
 
 def assemble_in_source_order(results_by_index, num_sources):

--- a/scripts/curate_navigator.py
+++ b/scripts/curate_navigator.py
@@ -167,6 +167,29 @@ def validate_navigation(navigation, sources_config):
     if not isinstance(hidden, list):
         errors.append("navigation.json: 'hidden' must be a list")
 
+    # Optional 'eyebrows' block, consumed by suppress_eyebrows.py: a global
+    # on/off switch, plus 'landing' — a dedicated override for the
+    # docc-merge-synthesized combined landing page ("Project"), which has no
+    # backing module entry to carry a per-entry 'eyebrow' field. Per-module
+    # overrides instead live on the module entries themselves (validated
+    # below, alongside 'source'/'path') and are collected by
+    # collect_eyebrow_overrides().
+    eyebrows = navigation.get("eyebrows")
+    if eyebrows is not None:
+        if not isinstance(eyebrows, dict):
+            errors.append("navigation.json: 'eyebrows' must be an object")
+        else:
+            suppress = eyebrows.get("suppress")
+            if suppress is not None and not isinstance(suppress, bool):
+                errors.append(
+                    "navigation.json: 'eyebrows.suppress' must be a boolean"
+                )
+            landing = eyebrows.get("landing")
+            if landing is not None and not isinstance(landing, str):
+                errors.append(
+                    "navigation.json: 'eyebrows.landing' must be a string (or null)"
+                )
+
     # Per-group shape. `title` is optional: omit it (or set it to null) for a
     # headerless group, whose modules render with no groupMarker in the
     # sidebar and no titled section on the landing page. When present it
@@ -206,6 +229,12 @@ def validate_navigation(navigation, sources_config):
                 )
                 continue
 
+            if "eyebrow" in entry:
+                errors.append(
+                    f"navigation.json: external entry '{_entry_label(entry)}' has "
+                    "'eyebrow' (there is no backing page to apply it to)"
+                )
+
             if isinstance(url, str) and url:
                 if ("url", url) in seen_identifiers:
                     errors.append(
@@ -233,6 +262,11 @@ def validate_navigation(navigation, sources_config):
                     f"navigation.json: path '{path}' appears more than once"
                 )
             seen_identifiers.add(("path", path))
+        if "eyebrow" in entry and not isinstance(entry["eyebrow"], str):
+            errors.append(
+                f"navigation.json: {_entry_label(entry) or path or '(entry)'} has "
+                "an 'eyebrow' that must be a string"
+            )
 
     # Completeness: every source must be represented (placed or hidden).
     for sid in sorted(s for s in source_ids if s):
@@ -243,6 +277,36 @@ def validate_navigation(navigation, sources_config):
             )
 
     return errors
+
+
+def collect_eyebrow_overrides(navigation):
+    """Build the {path: eyebrow_text} map suppress_eyebrows.py needs, sourced
+    from navigation.json rather than a separately-maintained table.
+
+    Walks every module entry (in a group or under 'hidden') that carries an
+    'eyebrow' field, keyed by that entry's 'path' — the same path already
+    used to identify it elsewhere. External entries have no backing page and
+    are skipped even if malformed enough to carry one (validate_navigation()
+    is what reports that as an error).
+
+    The synthesized combined landing page (`/documentation`) has no module
+    entry to attach an 'eyebrow' to, so it's carried separately in
+    `eyebrows.landing` and folded in here under its fixed path.
+    """
+    overrides = {}
+    for entry, _where in _entries(navigation):
+        if _is_external_entry(entry):
+            continue
+        path = entry.get("path")
+        eyebrow = entry.get("eyebrow")
+        if path and isinstance(eyebrow, str):
+            overrides[path] = eyebrow
+
+    landing = (navigation.get("eyebrows") or {}).get("landing")
+    if isinstance(landing, str):
+        overrides["/documentation"] = landing
+
+    return overrides
 
 
 def _group_paths(navigation):

--- a/scripts/navigation.json
+++ b/scripts/navigation.json
@@ -1,5 +1,9 @@
 {
   "version": 1,
+  "eyebrows": {
+    "suppress": true,
+    "landing": null
+  },
   "groups": [
     {
       "modules": [

--- a/scripts/suppress_eyebrows.py
+++ b/scripts/suppress_eyebrows.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+"""
+suppress-eyebrows.py — Blank or override the DocC "eyebrow" label on
+collection pages in a DocC archive.
+
+Every module/framework landing page in a Swift.doccarchive — and the `docc
+merge`-synthesized combined landing page — has `metadata.role == "collection"`
+plus a `metadata.roleHeading` string that swift-docc-render shows as a small
+label above the page title ("Framework", "Platforms", "Project", etc). Walks
+every JSON file under <archive>/data/ and, for each render node with
+role == "collection", rewrites roleHeading per an `eyebrows` config (the shape
+stored under navigation.json's top-level "eyebrows" key):
+
+  - `overrides[slug]` wins outright, where `slug` is the file's path relative
+    to data/ with no extension and a leading "/" — e.g. "/documentation/swift"
+    for a module page, or "/documentation" for the synthesized landing page.
+  - Otherwise `suppress: true` blanks roleHeading to "".
+  - Otherwise the page is left untouched.
+
+This isn't baked into any prerendered HTML — swift-docc-render fetches this
+JSON at runtime — but it must still run before `docc process-archive
+transform-for-static-hosting`, which replaces the archive wholesale; see
+hacking-synthesized-landing-page.md for why edits to data/*.json must precede
+that step.
+
+Usage:
+    ./suppress_eyebrows.py path/to/archive.doccarchive [--suppress] \
+        [--override /documentation/swift=Framework ...]
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+
+def _slug_for(data_dir, path):
+    """The file's path relative to data/, minus '.json', with a leading '/'."""
+    rel = os.path.relpath(path, data_dir)
+    if rel.endswith(".json"):
+        rel = rel[: -len(".json")]
+    return "/" + rel.replace(os.sep, "/")
+
+
+def process_file(path, slug, suppress, overrides):
+    with open(path, "rb") as f:
+        doc = json.load(f)
+
+    metadata = doc.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("role") != "collection":
+        return False
+    if "roleHeading" not in metadata:
+        return False
+
+    if slug in overrides:
+        new_value = overrides[slug]
+    elif suppress:
+        new_value = ""
+    else:
+        return False
+
+    if metadata["roleHeading"] == new_value:
+        return False
+    metadata["roleHeading"] = new_value
+
+    dir_ = os.path.dirname(path)
+    fd, tmp = tempfile.mkstemp(prefix=".eyebrows-", dir=dir_)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(doc, f, separators=(",", ":"), ensure_ascii=False)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+    return True
+
+
+def suppress_archive(archive_path, eyebrows_config=None):
+    """Apply `eyebrows_config` (navigation.json's "eyebrows" object) to a
+    merged .doccarchive.
+
+    Returns (files_scanned, files_modified). A falsy/absent config (suppress
+    not set, no overrides) is a true no-op — the archive isn't even checked
+    for a data/ directory — since that's the default, off state and this
+    runs unconditionally on every build. Raises ValueError if archive_path
+    doesn't look like a .doccarchive (missing data/ directory) whenever
+    there's actually something to apply.
+    """
+    eyebrows_config = eyebrows_config or {}
+    suppress = bool(eyebrows_config.get("suppress", False))
+    overrides = eyebrows_config.get("overrides") or {}
+
+    if not suppress and not overrides:
+        return 0, 0
+
+    archive = os.fspath(archive_path)
+    data_dir = os.path.join(archive, "data")
+    if not os.path.isdir(data_dir):
+        raise ValueError(
+            f"{archive!r} does not look like a .doccarchive "
+            f"(missing data/ directory)"
+        )
+
+    files_scanned = 0
+    files_modified = 0
+
+    for root, _, names in os.walk(data_dir):
+        for name in names:
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(root, name)
+            files_scanned += 1
+            slug = _slug_for(data_dir, path)
+            try:
+                modified = process_file(path, slug, suppress, overrides)
+            except json.JSONDecodeError as e:
+                sys.stderr.write(f"skip (invalid JSON): {path}: {e}\n")
+                continue
+            if modified:
+                files_modified += 1
+
+    return files_scanned, files_modified
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Blank or override the DocC eyebrow label on collection pages."
+    )
+    parser.add_argument("archive", help="Path to a .doccarchive")
+    parser.add_argument(
+        "--suppress", action="store_true",
+        help="Blank roleHeading on every collection page (default: off)",
+    )
+    parser.add_argument(
+        "--override", action="append", default=[], metavar="SLUG=TEXT",
+        help="Force a specific page's roleHeading, e.g. "
+             "/documentation/swift=Framework. Repeatable.",
+    )
+    args = parser.parse_args()
+
+    overrides = {}
+    for item in args.override:
+        slug, _, text = item.partition("=")
+        overrides[slug] = text
+
+    try:
+        scanned, modified = suppress_archive(
+            args.archive, {"suppress": args.suppress, "overrides": overrides}
+        )
+    except ValueError as e:
+        sys.stderr.write(f"error: {e}\n")
+        sys.exit(1)
+
+    print(f"scanned {scanned} files; modified {modified}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import build_docs  # noqa: E402
 import curate_navigator  # noqa: E402
 import strip_availability  # noqa: E402
+import suppress_eyebrows  # noqa: E402
 import validate_navigation as validate_navigation_cli  # noqa: E402
 
 
@@ -626,6 +627,125 @@ class StripArchive(unittest.TestCase):
                 strip_availability.strip_archive(not_an_archive)
 
 
+def _make_archive_with_collections(root, archive_name="Combined.doccarchive"):
+    """Build a minimal merged .doccarchive tree with two module landing pages,
+    the synthesized combined landing page, and one non-collection page.
+
+    Returns the archive path.
+    """
+    archive = root / archive_name
+    doc_dir = archive / "data" / "documentation"
+    doc_dir.mkdir(parents=True)
+
+    (archive / "data" / "documentation.json").write_text(json.dumps({
+        "metadata": {"title": "Swift Documentation", "role": "collection",
+                     "roleHeading": "Project"},
+    }))
+    (doc_dir / "swift.json").write_text(json.dumps({
+        "metadata": {"title": "Swift", "role": "collection",
+                     "roleHeading": "Framework"},
+    }))
+    (doc_dir / "userdocs.json").write_text(json.dumps({
+        "metadata": {"title": "VS Code", "role": "collection", "roleHeading": ""},
+    }))
+    (doc_dir / "closedrange.json").write_text(json.dumps({
+        "metadata": {"title": "ClosedRange", "role": "symbol",
+                     "roleHeading": "Structure"},
+    }))
+
+    return archive
+
+
+class SuppressEyebrowsArchive(unittest.TestCase):
+    def test_no_config_is_a_true_no_op(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_collections(Path(tmp))
+            before = (archive / "data" / "documentation" / "swift.json").read_text()
+
+            scanned, modified = suppress_eyebrows.suppress_archive(archive)
+
+            self.assertEqual((scanned, modified), (0, 0))
+            after = (archive / "data" / "documentation" / "swift.json").read_text()
+            self.assertEqual(before, after)
+
+    def test_suppress_true_blanks_only_collection_roleheadings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_collections(Path(tmp))
+
+            scanned, modified = suppress_eyebrows.suppress_archive(
+                archive, {"suppress": True}
+            )
+
+            landing = json.loads(
+                (archive / "data" / "documentation.json").read_text()
+            )
+            swift = json.loads(
+                (archive / "data" / "documentation" / "swift.json").read_text()
+            )
+            symbol = json.loads(
+                (archive / "data" / "documentation" / "closedrange.json").read_text()
+            )
+            self.assertEqual(landing["metadata"]["roleHeading"], "")
+            self.assertEqual(swift["metadata"]["roleHeading"], "")
+            # Non-collection pages are left untouched.
+            self.assertEqual(symbol["metadata"]["roleHeading"], "Structure")
+            self.assertEqual(scanned, 4)
+            # userdocs.json was already "", landing + swift actually changed.
+            self.assertEqual(modified, 2)
+
+    def test_override_wins_over_suppress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_collections(Path(tmp))
+
+            suppress_eyebrows.suppress_archive(archive, {
+                "suppress": True,
+                "overrides": {"/documentation/swift": "Standard Library"},
+            })
+
+            swift = json.loads(
+                (archive / "data" / "documentation" / "swift.json").read_text()
+            )
+            landing = json.loads(
+                (archive / "data" / "documentation.json").read_text()
+            )
+            self.assertEqual(swift["metadata"]["roleHeading"], "Standard Library")
+            self.assertEqual(landing["metadata"]["roleHeading"], "")
+
+    def test_override_applies_without_global_suppress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_collections(Path(tmp))
+
+            suppress_eyebrows.suppress_archive(archive, {
+                "overrides": {"/documentation": ""},
+            })
+
+            landing = json.loads(
+                (archive / "data" / "documentation.json").read_text()
+            )
+            swift = json.loads(
+                (archive / "data" / "documentation" / "swift.json").read_text()
+            )
+            self.assertEqual(landing["metadata"]["roleHeading"], "")
+            # Untouched: not overridden and global suppress is off.
+            self.assertEqual(swift["metadata"]["roleHeading"], "Framework")
+
+    def test_missing_data_dir_raises_when_config_is_active(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            not_an_archive = Path(tmp) / "NotAnArchive"
+            not_an_archive.mkdir()
+            with self.assertRaises(ValueError):
+                suppress_eyebrows.suppress_archive(
+                    not_an_archive, {"suppress": True}
+                )
+
+    def test_missing_data_dir_is_ignored_when_config_is_inactive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            not_an_archive = Path(tmp) / "NotAnArchive"
+            not_an_archive.mkdir()
+            scanned, modified = suppress_eyebrows.suppress_archive(not_an_archive)
+            self.assertEqual((scanned, modified), (0, 0))
+
+
 class TransformStaticHosting(unittest.TestCase):
     def test_invokes_docc_with_correct_args_and_replaces_in_place(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -883,7 +1003,7 @@ class FinalizeCombinedArchive(unittest.TestCase):
                 succeeded, failed = build_docs._finalize_combined_archive(
                     [archive], tmp_path, "main", ["docc"], prior_failed=[]
                 )
-        self.assertEqual(succeeded, ["combined-merge"])
+        self.assertEqual(succeeded, ["combined-merge", "eyebrow-suppression"])
         self.assertEqual(failed, ["static-hosting-transform"])
 
     def test_merge_uses_fixed_landing_page_name_regardless_of_version(self):
@@ -935,7 +1055,10 @@ class FinalizeCombinedArchive(unittest.TestCase):
                 succeeded, failed = build_docs._finalize_combined_archive(
                     [archive], tmp_path, "main", ["docc"], prior_failed=[]
                 )
-        self.assertEqual(succeeded, ["combined-merge", "static-hosting-transform"])
+        self.assertEqual(
+            succeeded,
+            ["combined-merge", "eyebrow-suppression", "static-hosting-transform"],
+        )
         self.assertEqual(failed, [])
 
     def _merge_writes_index(self, modules):
@@ -1016,7 +1139,8 @@ class FinalizeCombinedArchive(unittest.TestCase):
                 )
         self.assertEqual(
             succeeded,
-            ["combined-merge", "navigator-curation", "static-hosting-transform"],
+            ["combined-merge", "navigator-curation", "eyebrow-suppression",
+             "static-hosting-transform"],
         )
         self.assertEqual(failed, [])
 
@@ -1414,6 +1538,69 @@ class ValidateNavigation(unittest.TestCase):
             curate_navigator.validate_navigation(self._nav(), self.SOURCES), []
         )
 
+    def test_eyebrows_valid_shape_has_no_errors(self):
+        nav = self._nav(eyebrows={"suppress": True, "landing": "Project"})
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
+    def test_eyebrows_non_object_is_reported(self):
+        nav = self._nav(eyebrows=True)
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("'eyebrows' must be an object" in e for e in errors), errors)
+
+    def test_eyebrows_suppress_non_bool_is_reported(self):
+        nav = self._nav(eyebrows={"suppress": "yes"})
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(
+            any("'eyebrows.suppress' must be a boolean" in e for e in errors), errors
+        )
+
+    def test_eyebrows_landing_non_string_is_reported(self):
+        nav = self._nav(eyebrows={"landing": 42})
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(
+            any("'eyebrows.landing' must be a string" in e for e in errors), errors
+        )
+
+    def test_eyebrows_landing_null_is_valid(self):
+        nav = self._nav(eyebrows={"suppress": False, "landing": None})
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
+    def test_module_eyebrow_field_is_valid(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift", "eyebrow": "Standard Library"},
+            ]},
+        ])
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
+    def test_module_eyebrow_non_string_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift", "eyebrow": 7},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(
+            any("'eyebrow' that must be a string" in e for e in errors), errors
+        )
+
+    def test_hidden_module_eyebrow_field_is_valid(self):
+        nav = self._nav(hidden=[
+            {"source": "b", "path": "/documentation/internal", "eyebrow": "Framework"},
+        ])
+        self.assertEqual(curate_navigator.validate_navigation(nav, self.SOURCES), [])
+
+    def test_external_entry_eyebrow_is_reported(self):
+        nav = self._nav(groups=[
+            {"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+                {"title": "C++ Interop", "url": "https://www.swift.org/x/",
+                 "eyebrow": "Nope"},
+            ]},
+        ])
+        errors = curate_navigator.validate_navigation(nav, self.SOURCES)
+        self.assertTrue(any("has 'eyebrow'" in e for e in errors), errors)
+
     def test_unknown_source_is_reported(self):
         nav = self._nav(groups=[
             {"title": "Lang", "modules": [
@@ -1629,6 +1816,59 @@ class ValidateNavigation(unittest.TestCase):
         hidden_errors = [e for e in errors if "not valid under 'hidden'" in e]
         self.assertEqual(len(hidden_errors), 1, errors)
         self.assertFalse(any("appears more than once" in e for e in errors), errors)
+
+
+class CollectEyebrowOverrides(unittest.TestCase):
+    def test_gathers_group_and_hidden_module_eyebrows(self):
+        nav = {
+            "groups": [
+                {"title": "Lang", "modules": [
+                    {"source": "a", "path": "/documentation/swift",
+                     "eyebrow": "Standard Library"},
+                    {"source": "b", "path": "/documentation/testing"},
+                ]},
+            ],
+            "hidden": [
+                {"source": "a", "path": "/documentation/cxx", "eyebrow": "Framework"},
+            ],
+        }
+        overrides = curate_navigator.collect_eyebrow_overrides(nav)
+        self.assertEqual(overrides, {
+            "/documentation/swift": "Standard Library",
+            "/documentation/cxx": "Framework",
+        })
+
+    def test_ignores_external_entries_even_if_they_carry_eyebrow(self):
+        nav = {
+            "groups": [
+                {"title": "Lang", "modules": [
+                    {"title": "Foundation", "url": "https://developer.apple.com/x",
+                     "eyebrow": "Nope"},
+                ]},
+            ],
+            "hidden": [],
+        }
+        self.assertEqual(curate_navigator.collect_eyebrow_overrides(nav), {})
+
+    def test_landing_override_maps_to_documentation_root(self):
+        nav = {"groups": [], "hidden": [], "eyebrows": {"landing": "Project"}}
+        self.assertEqual(
+            curate_navigator.collect_eyebrow_overrides(nav),
+            {"/documentation": "Project"},
+        )
+
+    def test_no_eyebrows_block_and_no_module_eyebrows_returns_empty(self):
+        nav = {
+            "groups": [{"title": "Lang", "modules": [
+                {"source": "a", "path": "/documentation/swift"},
+            ]}],
+            "hidden": [],
+        }
+        self.assertEqual(curate_navigator.collect_eyebrow_overrides(nav), {})
+
+    def test_landing_null_is_omitted(self):
+        nav = {"groups": [], "hidden": [], "eyebrows": {"landing": None}}
+        self.assertEqual(curate_navigator.collect_eyebrow_overrides(nav), {})
 
 
 class CurateNavigator(unittest.TestCase):


### PR DESCRIPTION

## Summary

adds scripting to surpress the "eyebrows" for modules

This isn't the ideal way to to this - it should come from within module, but we want the combination of content to be consistent. We can back this out entirely (cease surpressing or overriding) as upstream content aligns, assuming it'll agree in all cases (swift-testing, for example, may use a different structure when it's published on developer.apple.com)

- controlled in navigation.json
- per-module overrides possible, but not enabled by default
- tests to validate
- default (now) to surpress on all for consistency's sake

## Validation

Local run with all eyebrows suppressed:

<img width="1363" height="1171" alt="Screenshot 2026-08-17 at 1 12 23 PM" src="https://github.com/user-attachments/assets/1cb8c99a-d936-4ba0-bb27-4da8d5831a2a" />

<img width="1363" height="1171" alt="Screenshot 2026-08-17 at 1 13 49 PM" src="https://github.com/user-attachments/assets/81f874d8-1cef-4be0-87db-faa1b89bf682" />

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
