### PR TITLE
Fix links

### DIFF
--- a/libraries/Sources/Libraries.docc/Documentation.md
+++ b/libraries/Sources/Libraries.docc/Documentation.md
@@ -10,8 +10,8 @@ Official libraries maintained by the Swift project.
 ## Concurrency and process libraries
 
 - [swift-subprocess](https://swiftpackageindex.com/swiftlang/swift-subprocess) — Cross-platform process spawning package
-- [swift-platform-executors](https://swiftpackageindex.com/swiftlang/swift-platform-executors) — Platform-native executors for Swift Concurrency
-- [swift-corelibs-libdispatch](https://swiftpackageindex.com/swiftlang/swift-corelibs-libdispatch) — Grand Central Dispatch for multicore concurrency
+- [swift-platform-executors](https://github.com/swiftlang/swift-platform-executors) — Platform-native executors for Swift Concurrency
+- [swift-corelibs-libdispatch](https://github.com/swiftlang/swift-corelibs-libdispatch) — Grand Central Dispatch for multicore concurrency
 
 ## Source parsing and text libraries
 

--- a/linux/Sources/SwiftLinux.docc/ServerGuides.md
+++ b/linux/Sources/SwiftLinux.docc/ServerGuides.md
@@ -4,7 +4,7 @@ Build, package, and deploy Swift applications for Linux servers and cloud infras
 
 ## Tutorials
 
-- [Get Started with Swift Server](https://docs.swift.org/latest/tutorials/getting-started-swift-server) — Explore Swift on the server by building a Vapor app.
+- [Get Started with Swift Server](https://www.swift.org/getting-started/vapor-web-server/) — Explore Swift on the server by building a Vapor app.
 
 ## Topics
 


### PR DESCRIPTION
## Summary

Fixed links for assumptions about core library repos that were mirrored in Swift Package Index that aren't - referencing GitHub directly in those cases.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
