### PR TITLE
adds post-processing step to suppress multi-language header/toggle 

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -29,6 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from strip_availability import strip_archive
+from strip_language_toggle import strip_archive as strip_language_toggle_archive
 from suppress_eyebrows import suppress_archive as suppress_eyebrow_archive
 from curate_navigator import (
     curate_navigator,
@@ -850,6 +851,18 @@ def _finalize_combined_archive(all_archives, output_dir, version_slug, docc_cmd,
         return prior_steps, ["eyebrow-suppression"]
 
     prior_steps.append("eyebrow-suppression")
+
+    try:
+        scanned, modified = strip_language_toggle_archive(combined_output)
+        print(
+            f"Language toggle suppression: scanned {scanned} file(s), "
+            f"modified {modified}."
+        )
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Error: language toggle suppression failed: {e}")
+        return prior_steps, ["language-toggle-suppression"]
+
+    prior_steps.append("language-toggle-suppression")
 
     try:
         transform_static_hosting(combined_output, hosting_base_path or version_slug, docc_cmd)

--- a/scripts/strip_language_toggle.py
+++ b/scripts/strip_language_toggle.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+"""
+strip_language_toggle.py — Remove the interface-language variant data that
+drives swift-docc-render's "Language: Swift" nav pill from a DocC archive.
+
+DocC only attaches a top-level `variants` array (traits like
+`{"interfaceLanguage": "swift"}`) to render nodes produced from a compiled
+symbol graph — every page built via `swift package generate-documentation`,
+whether or not the target has any real public symbols — and to prebuilt
+archives fetched already containing one (e.g. the downloaded stdlib
+archive). Pages converted straight from a bare `.docc` catalog via `docc
+convert`, with no compiled target behind them, never get one.
+swift-docc-render's `LanguageToggle` nav item keys off exactly this array
+(`DocumentationTopic.vue`'s `swiftPath`/`objcPath` computed properties read
+`variant.traits[].interfaceLanguage`), so the pill ends up showing on some
+pages and not others — a build-path artifact, not a per-page choice.
+
+Walks every JSON file under <archive>/data/ and deletes the render node's
+own top-level "variants" key wherever present. Does NOT recurse: "variants"
+is also a legitimate key elsewhere in the same document — e.g.
+`references.<id>.variants` on an image/video asset reference, holding its
+light/dark or resolution variants — and deleting those would break asset
+rendering.
+
+Usage:
+    ./strip_language_toggle.py path/to/archive.doccarchive
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+TARGET_KEY = "variants"
+
+
+def process_file(path):
+    with open(path, "rb") as f:
+        data = json.load(f)
+
+    if not isinstance(data, dict) or TARGET_KEY not in data:
+        return False
+    del data[TARGET_KEY]
+
+    dir_ = os.path.dirname(path)
+    fd, tmp = tempfile.mkstemp(prefix=".strip-language-", dir=dir_)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, separators=(",", ":"), ensure_ascii=False)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+    return True
+
+
+def strip_archive(archive_path):
+    """Delete the top-level 'variants' key from every render node JSON file
+    under <archive>/data/.
+
+    Returns (files_scanned, files_modified). Raises ValueError if
+    archive_path doesn't look like a .doccarchive (missing data/ directory).
+    """
+    archive = os.fspath(archive_path)
+    data_dir = os.path.join(archive, "data")
+    if not os.path.isdir(data_dir):
+        raise ValueError(
+            f"{archive!r} does not look like a .doccarchive "
+            f"(missing data/ directory)"
+        )
+
+    files_scanned = 0
+    files_modified = 0
+
+    for root, _, names in os.walk(data_dir):
+        for name in names:
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(root, name)
+            files_scanned += 1
+            try:
+                modified = process_file(path)
+            except json.JSONDecodeError as e:
+                sys.stderr.write(f"skip (invalid JSON): {path}: {e}\n")
+                continue
+            if modified:
+                files_modified += 1
+
+    return files_scanned, files_modified
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write(f"usage: {sys.argv[0]} <path-to-doccarchive>\n")
+        sys.exit(2)
+
+    archive = os.path.abspath(sys.argv[1])
+    try:
+        files_scanned, files_modified = strip_archive(archive)
+    except ValueError as e:
+        sys.stderr.write(f"error: {e}\n")
+        sys.exit(1)
+
+    print(f"scanned {files_scanned} files; modified {files_modified}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_build_docs.py
+++ b/scripts/test_build_docs.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import build_docs  # noqa: E402
 import curate_navigator  # noqa: E402
 import strip_availability  # noqa: E402
+import strip_language_toggle  # noqa: E402
 import suppress_eyebrows  # noqa: E402
 import validate_navigation as validate_navigation_cli  # noqa: E402
 
@@ -627,6 +628,91 @@ class StripArchive(unittest.TestCase):
                 strip_availability.strip_archive(not_an_archive)
 
 
+def _make_archive_with_language_variants(root, archive_name="Swift.doccarchive"):
+    """Build a minimal .doccarchive tree with a module page carrying the
+    top-level `variants` array that drives the "Language: Swift" nav pill,
+    a docc-convert-style page with none, and an image reference whose own
+    `variants` key (light/dark asset variants) must survive untouched.
+
+    Returns the archive path.
+    """
+    archive = root / archive_name
+    doc_dir = archive / "data" / "documentation"
+    doc_dir.mkdir(parents=True)
+
+    (doc_dir / "testing.json").write_text(json.dumps({
+        "metadata": {"title": "Testing", "role": "collection"},
+        "variants": [
+            {"paths": ["/documentation/testing"],
+             "traits": [{"interfaceLanguage": "swift"}]},
+        ],
+        "references": {
+            "hero.png": {
+                "type": "image",
+                "variants": [{"traits": ["light"], "url": "/images/hero.png"}],
+            },
+        },
+    }))
+    (doc_dir / "userdocs.json").write_text(json.dumps({
+        "metadata": {"title": "VS Code", "role": "collection"},
+    }))
+
+    return archive
+
+
+class StripLanguageToggleArchive(unittest.TestCase):
+    def test_removes_top_level_variants_and_returns_counts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_language_variants(Path(tmp))
+            scanned, modified = strip_language_toggle.strip_archive(archive)
+
+            testing = json.loads(
+                (archive / "data" / "documentation" / "testing.json").read_text()
+            )
+            self.assertNotIn("variants", testing)
+            # Unrelated keys preserved.
+            self.assertEqual(testing["metadata"]["title"], "Testing")
+
+            self.assertEqual(scanned, 2)
+            self.assertEqual(modified, 1)
+
+    def test_nested_asset_variants_are_not_touched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_with_language_variants(Path(tmp))
+            strip_language_toggle.strip_archive(archive)
+
+            testing = json.loads(
+                (archive / "data" / "documentation" / "testing.json").read_text()
+            )
+            self.assertIn("variants", testing["references"]["hero.png"])
+            self.assertEqual(
+                testing["references"]["hero.png"]["variants"],
+                [{"traits": ["light"], "url": "/images/hero.png"}],
+            )
+
+    def test_archive_without_variants_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "Swift.doccarchive"
+            data_dir = archive / "data"
+            data_dir.mkdir(parents=True)
+            payload = {"metadata": {"title": "X"}, "kind": "article"}
+            (data_dir / "x.json").write_text(json.dumps(payload))
+
+            scanned, modified = strip_language_toggle.strip_archive(archive)
+            self.assertEqual(scanned, 1)
+            self.assertEqual(modified, 0)
+            self.assertEqual(
+                json.loads((data_dir / "x.json").read_text()), payload
+            )
+
+    def test_missing_data_dir_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            not_an_archive = Path(tmp) / "NotAnArchive"
+            not_an_archive.mkdir()
+            with self.assertRaises(ValueError):
+                strip_language_toggle.strip_archive(not_an_archive)
+
+
 def _make_archive_with_collections(root, archive_name="Combined.doccarchive"):
     """Build a minimal merged .doccarchive tree with two module landing pages,
     the synthesized combined landing page, and one non-collection page.
@@ -994,7 +1080,8 @@ class FinalizeCombinedArchive(unittest.TestCase):
                 # First call is `docc merge`; succeed by creating output dir.
                 if "merge" in cmd:
                     out_idx = cmd.index("--output-path") + 1
-                    Path(cmd[out_idx]).mkdir(parents=True, exist_ok=True)
+                    out = Path(cmd[out_idx])
+                    (out / "data").mkdir(parents=True, exist_ok=True)
                     return subprocess.CompletedProcess(cmd, 0)
                 # Second call is the transform; fail.
                 raise subprocess.CalledProcessError(1, cmd)
@@ -1003,7 +1090,10 @@ class FinalizeCombinedArchive(unittest.TestCase):
                 succeeded, failed = build_docs._finalize_combined_archive(
                     [archive], tmp_path, "main", ["docc"], prior_failed=[]
                 )
-        self.assertEqual(succeeded, ["combined-merge", "eyebrow-suppression"])
+        self.assertEqual(
+            succeeded,
+            ["combined-merge", "eyebrow-suppression", "language-toggle-suppression"],
+        )
         self.assertEqual(failed, ["static-hosting-transform"])
 
     def test_merge_uses_fixed_landing_page_name_regardless_of_version(self):
@@ -1029,7 +1119,7 @@ class FinalizeCombinedArchive(unittest.TestCase):
             name_idx = merge_cmd.index("--synthesized-landing-page-name") + 1
             self.assertEqual(merge_cmd[name_idx], "Swift Documentation")
 
-    def test_full_success_records_both_steps(self):
+    def test_full_success_records_all_steps(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             archive = tmp_path / "a.doccarchive"
@@ -1041,6 +1131,7 @@ class FinalizeCombinedArchive(unittest.TestCase):
                     out_idx = cmd.index("--output-path") + 1
                     out = Path(cmd[out_idx])
                     out.mkdir(parents=True, exist_ok=True)
+                    (out / "data").mkdir(parents=True, exist_ok=True)
                     (out / "index.html").write_text("merged")
                     return subprocess.CompletedProcess(cmd, 0)
                 # Transform step: simulate docc producing the transformed
@@ -1057,9 +1148,35 @@ class FinalizeCombinedArchive(unittest.TestCase):
                 )
         self.assertEqual(
             succeeded,
-            ["combined-merge", "eyebrow-suppression", "static-hosting-transform"],
+            ["combined-merge", "eyebrow-suppression", "language-toggle-suppression",
+             "static-hosting-transform"],
         )
         self.assertEqual(failed, [])
+
+    def test_language_toggle_suppression_failure_records_only_that_step(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "a.doccarchive"
+            archive.mkdir()
+            (archive / "index.html").write_text("ok")
+
+            def fake_run(cmd, **kw):
+                out_idx = cmd.index("--output-path") + 1
+                out = Path(cmd[out_idx])
+                out.mkdir(parents=True, exist_ok=True)
+                (out / "index.html").write_text("merged")
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with mock.patch.object(build_docs.subprocess, "run", side_effect=fake_run):
+                with mock.patch.object(
+                    build_docs, "strip_language_toggle_archive",
+                    side_effect=OSError("boom"),
+                ):
+                    succeeded, failed = build_docs._finalize_combined_archive(
+                        [archive], tmp_path, "main", ["docc"], prior_failed=[]
+                    )
+        self.assertEqual(succeeded, ["combined-merge", "eyebrow-suppression"])
+        self.assertEqual(failed, ["language-toggle-suppression"])
 
     def _merge_writes_index(self, modules):
         """Build a fake subprocess.run that writes a merged index.json on merge.
@@ -1074,6 +1191,7 @@ class FinalizeCombinedArchive(unittest.TestCase):
             out.mkdir(parents=True, exist_ok=True)
             if "merge" in cmd:
                 (out / "index").mkdir(parents=True, exist_ok=True)
+                (out / "data").mkdir(parents=True, exist_ok=True)
                 doc = {
                     "schemaVersion": {"major": 0, "minor": 1, "patch": 2},
                     "interfaceLanguages": {
@@ -1140,7 +1258,7 @@ class FinalizeCombinedArchive(unittest.TestCase):
         self.assertEqual(
             succeeded,
             ["combined-merge", "navigator-curation", "eyebrow-suppression",
-             "static-hosting-transform"],
+             "language-toggle-suppression", "static-hosting-transform"],
         )
         self.assertEqual(failed, [])
 


### PR DESCRIPTION
## Summary

adds post-processing step to suppress multi-language header/toggle 

This shows up in some catalogs as an indicator that there *might* be variations of code examples (for example, legacy objective-c/swift) for API sets. None of that is relevant to the Swift documentation, so this removes that variant identification process that gets embedded in some of the module archives.

examples:
<img width="1363" height="1171" alt="before" src="https://github.com/user-attachments/assets/d17595c9-6a2f-4e61-8243-492d458f0310" />

and after the suppression:
<img width="1363" height="1171" alt="after" src="https://github.com/user-attachments/assets/d59e65f8-a451-467e-9642-1655ca4895b3" />


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
