### PR TITLE
re-enabling caching in CI flows - sourced on scripts/sources.json

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # - uses: actions/cache@v6
-      #   with:
-      #     path: .workspace
-      #     key: docs-workspace-${{ hashFiles('scripts/sources.json') }}
-      #     restore-keys: |
-      #       docs-workspace-
+      - uses: actions/cache@v6
+        with:
+          path: .workspace
+          key: docs-workspace-${{ hashFiles('scripts/sources.json') }}
+          restore-keys: |
+            docs-workspace-
 
       - name: Install Python
         run: apt-get update && apt-get install -y python3


### PR DESCRIPTION
## Summary

re-enables caching for build-docs job, so that all the cloning doesn't have to happen on every iteration when not upstream changes would have impacted it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
