### PR TITLE
removing interop libraries from libraries collection

### DIFF
--- a/libraries/Sources/Libraries.docc/Documentation.md
+++ b/libraries/Sources/Libraries.docc/Documentation.md
@@ -27,8 +27,3 @@ Official libraries maintained by the Swift project.
 - [swift-tools-protocols](https://swiftpackageindex.com/swiftlang/swift-tools-protocols) — LSP/BSP support types
 - [indexstore-db](https://swiftpackageindex.com/swiftlang/indexstore-db) — Index database library for sourcekit-lsp
 - [swift-llvm-bindings](https://swiftpackageindex.com/swiftlang/swift-llvm-bindings) — Swift bindings for LLVM APIs
-
-## Interoperability libraries
-
-- [swift-java](https://swiftpackageindex.com/swiftlang/swift-java) — Java interoperability support for Swift
-- [swift-java-jni-core](https://swiftpackageindex.com/swiftlang/swift-java-jni-core) — Core JNI support underlying swift-java


### PR DESCRIPTION


## Summary

Removes the "interop libraries" section of the library listing since that's a top-level item at docs.swift.org. This page/structure was set up to provide links to core libraries the Swift project uses before we added that, and I think it makes more sense to lean into the top-level docs and reference content there than to replicate it in this list.


## Validation

- [x] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [x] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
