### PR TITLE
Fix grammar in README (its own; provide a library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This repository isn't meant for consumable libraries, any documentation for a Sw
 This library hosts general content related to the Swift language, guides, and cross-cutting details that support the Swift ecosystem more broadly.
 Each of the catalogs is matched with an entry in the [CODEOWNERS][codeowners] file, which provides the technical reviewers for that catalog.
 
-Each directory has it's own Swift package in order to support a full breadth of tooling for documentation and examples, including snippets. 
-The packages in this repository aren't meant to be depended upon or provide library. 
+Each directory has its own Swift package in order to support a full breadth of tooling for documentation and examples, including snippets.
+The packages in this repository aren't meant to be depended upon or provide a library.
 
 ## How you can help
 


### PR DESCRIPTION
Two small grammatical corrections in the repository README overview, in the "What's in this repository" section:

- **"Each directory has it's own Swift package"** → **"its own"** — `it's` is the contraction of "it is"; the possessive is `its`.
- **"aren't meant to be depended upon or provide library"** → **"provide a library"** — missing article.

Also removes trailing whitespace on the two edited lines.

Per `CONTRIBUTING.md`, typo and small revision fixes are welcomed directly as pull requests. No content or behavior changes.