### PR TITLE
adds --enable-experimental-code-block-annotations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Package.resolved
 **/*.docc/header.html
 **/*.docc/footer.html
 scripts/__pycache__/
+.coverage
+.coverage.*

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -55,6 +55,7 @@ DOCC_BUILD_FLAGS = [
     "--experimental-enable-custom-templates",
     "--enable-mentioned-in",
     # "--enable-experimental-external-link-support",
+    "--enable-experimental-code-block-annotations",
     # Emit a markdown copy of every rendered document (plus a manifest) under
     # data/documentation/. These sidecar files survive docc merge and
     # process-archive transform-for-static-hosting, so they reach the published


### PR DESCRIPTION
## Summary

Adds the code block annotations that specifically trigger and enable the copy-to-clipboard for all code blocks in docs.swift.org

## Validation

- [ ] `swift package generate-documentation --analyze --warnings-as-errors` passes
- [ ] Previewed locally with `swift package --disable-sandbox preview-documentation`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
